### PR TITLE
CoreException due to deprecated extension points

### DIFF
--- a/platform-ui/plugins/org.eclipse.ui.examples.filesystem/plugin.xml
+++ b/platform-ui/plugins/org.eclipse.ui.examples.filesystem/plugin.xml
@@ -19,18 +19,19 @@
       <objectContribution
             id="org.eclipse.ui.examples.filesystem.contribution1"
             objectClass="org.eclipse.core.resources.IFile">
+         <action
+               class="org.eclipse.ui.examples.filesystem.ExpandZipAction"
+               enablesFor="1"
+               id="org.eclipse.ui.examples.filesystem.expandZip"
+               label="Expand Zip File"
+               menubarPath="additions">
          		<enablement>
 		            <or>
 		               <objectState name="extension" value="jar"/>
    		            <objectState name="extension" value="zip"/>
    		         </or>
          		</enablement>
-         <action
-               class="org.eclipse.ui.examples.filesystem.ExpandZipAction"
-               enablesFor="1"
-               id="org.eclipse.ui.examples.filesystem.expandZip"
-               label="Expand Zip File"
-               menubarPath="additions"/>
+       	</action>
       </objectContribution>
    </extension>
    <extension
@@ -38,18 +39,19 @@
       <objectContribution
             id="org.eclipse.ui.examples.filesystem.contribution2"
             objectClass="org.eclipse.core.resources.IFolder">
+         <action
+               class="org.eclipse.ui.examples.filesystem.CollapseZipAction"
+               enablesFor="1"
+               id="org.eclipse.ui.examples.filesystem.collapseZip"
+               label="Collapse Zip File"
+               menubarPath="additions">
          		<enablement>
 		            <or>
 		               <objectState name="extension" value="jar"/>
    		            <objectState name="extension" value="zip"/>
    		         </or>
          		</enablement>
-         <action
-               class="org.eclipse.ui.examples.filesystem.CollapseZipAction"
-               enablesFor="1"
-               id="org.eclipse.ui.examples.filesystem.collapseZip"
-               label="Collapse Zip File"
-               menubarPath="additions"/>
+           </action>
       </objectContribution>
    </extension>
    <extension


### PR DESCRIPTION
Hello everyone, we use the filesystem project in our application in order to create Eclipse projects that only exist in-memory, rather than on the file system. 

However, some of the UI contributions no longer seem to work on newer Eclipse versions and fail with an exception when, e.g. right-clicking on an object in our project explorer:

>org.eclipse.core.runtime.CoreException: Unknown expression element objectState > or > enablement > objectContribution (id=org.eclipse.ui.examples.filesystem.contribution1) : org.eclipse.ui.popupMenus @ org.eclipse.ui.examples.filesystem
	at org.eclipse.core.expressions.ExpressionConverter.processChildren(ExpressionConverter.java:128)
	at org.eclipse.core.expressions.ElementHandler.processChildren(ElementHandler.java:104)
	at org.eclipse.core.internal.expressions.StandardElementHandler.create(StandardElementHandler.java:34)
	at org.eclipse.core.expressions.ExpressionConverter.perform(ExpressionConverter.java:90)
	at org.eclipse.core.expressions.ExpressionConverter.processChildren(ExpressionConverter.java:126)
	at org.eclipse.core.expressions.ElementHandler.processChildren(ElementHandler.java:104)
	at org.eclipse.core.internal.expressions.StandardElementHandler.create(StandardElementHandler.java:64)
	at org.eclipse.core.expressions.ExpressionConverter.perform(ExpressionConverter.java:90)
        ...