### PR TITLE
Add N&N for auto-expand of single child elements in tree viewers

### DIFF
--- a/news/4.32/platform_isv.html
+++ b/news/4.32/platform_isv.html
@@ -24,7 +24,9 @@ ul {padding-left: 13px;}
 <h2>Platform and Equinox API</h2>
   <ul>
     <li><a href="#Platform">Platform Changes</a></li>
+<!--
     <li><a href="#SWT">SWT Changes</a></li>
+-->
   </ul>
 
 <!-- ****************** START OF N&N TABLE****************** -->
@@ -59,9 +61,11 @@ ul {padding-left: 13px;}
   <!-- ******************** End of Platform ********************** -->
 
   <!-- *********************** SWT *********************** -->
+<!--
   <tr>
     <td id="SWT" class="section" colspan="2"><h2>SWT Changes</h2></td>
   </tr>
+-->
   <!-- *********************** End of SWT *********************** -->
   <tr><td colspan="2"/></tr>
 </tbody>

--- a/news/4.32/platform_isv.html
+++ b/news/4.32/platform_isv.html
@@ -38,6 +38,24 @@ ul {padding-left: 13px;}
   <tr>
     <td id="Platform" class="section" colspan="2"><h2>Platform Changes</h2></td>
   </tr>
+
+  <tr id="treeviewer_autoexpand_singlechild"> <!-- https://github.com/eclipse-platform/eclipse.platform.ui/issues/1063 -->
+    <td class="title">Auto-Expand for Single Child Elements in JFace Tree Viewers</td>
+    <td class="content">
+      <p>
+        The API method
+        <code>org.eclipse.jface.viewers.AbstractTreeViewer.setAutoExpandOnSingleChildLevels(int level)</code> was added to
+        JFace. If this method is called on a tree viewer with some positive value or the constant <code>ALL_LEVELS</code>,
+        expanding a tree item that only has a single child element will lead to a recursive expansion of child items. The
+        recursive expansion stops once an item has more than one child item or the number of expansions reaches the value
+        passed to the method.
+      <p>
+      <p>
+        To ensure backwards compatibility, this feature is disabled by default. Each instantiation of a concrete
+        implementation of <code>AbstractTreeViewer</code> is responsible for enabling this feature if needed.
+      </p>
+    </td>
+  </tr>
   <!-- ******************** End of Platform ********************** -->
 
   <!-- *********************** SWT *********************** -->


### PR DESCRIPTION
Issue: https://github.com/eclipse-platform/eclipse.platform.ui/issues/1063

PR: https://github.com/eclipse-platform/eclipse.platform.ui/pull/1072

Also removes the empty SWT sections from the page for the 4.32 release.