### PR TITLE
N&N 4.32: Correct link anchor

### DIFF
--- a/news/4.32/jdt.html
+++ b/news/4.32/jdt.html
@@ -96,7 +96,7 @@ ul {padding-left: 13px;}
       <p><img src="images/string-format-after.png" alt="after changing to String.format" width="800"/></p>
     </td>
   </tr>
-  <tr id="combine-decl-and-assigment">
+  <tr id="combine-decl-and-assignment">
     <td class="title"><a href="#combine-decl-and-assignment">Combine declaration and assignment</a></td>
     <td class="content">
       <!-- https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1330 -->


### PR DESCRIPTION
Typo in link anchor, but correctly in the link: `combine-decl-and-assig(n)ment` (`assignment` with vs. without `n`)