### PR TITLE
Fix links and text of README for 4.32

### DIFF
--- a/development/readme_eclipse_4.32.html
+++ b/development/readme_eclipse_4.32.html
@@ -188,7 +188,7 @@ after the release.
   </p>
   <p>
     Eclipse 4.32 is tested and validated on a number of reference platforms. For the complete list, see <a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=https://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_31.xml#target_environments">Target Environments in the
+      href="https://www.eclipse.org/projects/project-plan.php?planurl=https://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_32.xml#target_environments">Target Environments in the
       4.32 Plan</a>.
   </p>
   <p>
@@ -219,20 +219,20 @@ after the release.
     <a
       class="mozTocH3"
       name="mozTocId324309"> <strong>API Contract Compatibility:</strong> Eclipse SDK 4.32 is upwards contract-compatible with Eclipse SDK 4.31 except in those areas noted in the
-    </a><a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_31_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
+    </a><a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_32_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
     will need to be ported to Eclipse SDK 4.32 APIs. Downward contract compatibility is not supported. There is no guarantee that compliance with Eclipse SDK 4.32 APIs would ensure compliance with
     Eclipse SDK 4.31 APIs. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"><em>Evolving Java-based APIs</em></a> for a discussion of the kinds of API changes that maintain contract
     compatibility.
   </p>
   <p>
     <strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.32 is upwards binary-compatible with Eclipse SDK 4.31 except in those areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_31_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
+      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_32_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
     Plug-ins for Eclipse SDK 4.32 will not be usable in Eclipse SDK 4.31. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"> <em>Evolving Java-based APIs</em></a> for a discussion of
     the kinds of API changes that maintain binary compatibility.
   </p>
   <p>
     <strong>Source Compatibility:</strong> Eclipse SDK 4.32 is upwards source-compatible with Eclipse SDK 4.31 except in the areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_31_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
+      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_32_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
     SDK 4.32 APIs might successfully compile and run against Eclipse SDK 4.31 APIs, although this is not guaranteed. Downward source compatibility is not supported. If source files use new Eclipse SDK
     APIs, they will not be usable with an earlier version of the Eclipse SDK.
   </p>

--- a/development/readme_eclipse_4.32.html
+++ b/development/readme_eclipse_4.32.html
@@ -176,9 +176,9 @@ after the release.
   <p>Most of the Eclipse SDK is "pure" Java code and has no direct dependence on the underlying operating system. The chief dependence is therefore on the Java Platform itself. Portions are
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
-  <p>In general, the 4.32 release of the Eclipse Project is developed on Java SE 17 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
   <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
+    In general, the 4.32 release of the Eclipse Project is developed on Java SE 17 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.
+    The IDE itself, however, requires Java 21 to run correctly, see <a href="https://www.eclipse.org/setups/sponsor/?scope=Eclipse%20IDE&campaign=2024-06">here</a> for more information.
   </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
@@ -279,7 +279,7 @@ after the release.
   <ul>
     <li><a
       class="mozTocH4"
-      name="mozTocId693657">As shown </a><a href="#TargetOperatingEnvironments">above</a>, Eclipse 4.32 requires at least a Java SE 17. Perhaps an older version of the VM is being found in your path. To
+      name="mozTocId693657">As shown </a><a href="#TargetOperatingEnvironments">above</a>, Eclipse 4.32 requires at least a Java SE 21. Perhaps an older version of the VM is being found in your path. To
       explicitly specify which VM to run with, use the Eclipse <code>-vm</code> command-line argument. (See also the <a href="#RunningEclipse">Running Eclipse</a> section below.)</li>
     <li>Eclipse must be installed to a clean directory and not installed over top of a previous installation. If you have done this then please re-install to a new directory. If your workspace is
       in a child directory of your old installation directory, then see the instructions below on "<a href="#Upgrading">Upgrading Workspace from a Previous Release"</a>.
@@ -1104,7 +1104,7 @@ after the release.
   <p>
     <a
       class="mozTocH2"
-      name="mozTocId19817"> After installing the Eclipse SDK in a directory, you can start the Workbench by running the Eclipse executable included with the release (you also need a Java SE 17 JRE,
+      name="mozTocId19817"> After installing the Eclipse SDK in a directory, you can start the Workbench by running the Eclipse executable included with the release (you also need a Java SE 21 JRE,
       not included with the Eclipse SDK). With Oomph users can install required JRE courtesy of <a href="https://www.eclipse.org/justj">JustJ</a>. On Windows, the executable file is called <samp>eclipse.exe</samp> , and is located in the <code>eclipse</code> sub-directory of the install. If installed at
       <code>c:\eclipse-SDK-4.32-win64</code> , the executable is <code>c:\eclipse-SDK-4.32-win64\eclipse\eclipse.exe</code> . <b>Note:</b> Set-up on most other operating environments is analogous.
       Special instructions for Mac OS X are listed

--- a/development/readme_eclipse_4.32.html
+++ b/development/readme_eclipse_4.32.html
@@ -178,7 +178,7 @@ after the release.
     5, etc).</p>
   <p>
     In general, the 4.32 release of the Eclipse Project is developed on Java SE 17 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.
-    The IDE itself, however, requires Java 21 to run correctly, see <a href="https://www.eclipse.org/setups/sponsor/?scope=Eclipse%20IDE&campaign=2024-06">here</a> for more information.
+    The <a href="https://www.eclipse.org/downloads/packages/">EPP packages</a>, however, require Java 21 to run correctly, see <a href="https://www.eclipse.org/setups/sponsor/?scope=Eclipse%20IDE&campaign=2024-06">here</a> for more information.
   </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
@@ -279,7 +279,8 @@ after the release.
   <ul>
     <li><a
       class="mozTocH4"
-      name="mozTocId693657">As shown </a><a href="#TargetOperatingEnvironments">above</a>, Eclipse 4.32 requires at least a Java SE 21. Perhaps an older version of the VM is being found in your path. To
+      name="mozTocId693657">As shown </a><a href="#TargetOperatingEnvironments">above</a>, Eclipse 4.32 requires at least a Java SE 17, but Java SE 21 is
+      recommended for greater compatibility with plugins that already have higher requirements. Perhaps an older version of the VM is being found in your path. To
       explicitly specify which VM to run with, use the Eclipse <code>-vm</code> command-line argument. (See also the <a href="#RunningEclipse">Running Eclipse</a> section below.)</li>
     <li>Eclipse must be installed to a clean directory and not installed over top of a previous installation. If you have done this then please re-install to a new directory. If your workspace is
       in a child directory of your old installation directory, then see the instructions below on "<a href="#Upgrading">Upgrading Workspace from a Previous Release"</a>.
@@ -1104,8 +1105,9 @@ after the release.
   <p>
     <a
       class="mozTocH2"
-      name="mozTocId19817"> After installing the Eclipse SDK in a directory, you can start the Workbench by running the Eclipse executable included with the release (you also need a Java SE 21 JRE,
-      not included with the Eclipse SDK). With Oomph users can install required JRE courtesy of <a href="https://www.eclipse.org/justj">JustJ</a>. On Windows, the executable file is called <samp>eclipse.exe</samp> , and is located in the <code>eclipse</code> sub-directory of the install. If installed at
+      name="mozTocId19817"> After installing the Eclipse SDK in a directory, you can start the Workbench by running the Eclipse executable included with the release. You also need a Java SE JRE of
+      the right version which is not included with the Eclipse SDK (see the <a href="#TargetOperatingEnvironments2">target environments</a> section above for details).
+      With Oomph users can install the required JRE courtesy of <a href="https://www.eclipse.org/justj">JustJ</a>. On Windows, the executable file is called <samp>eclipse.exe</samp> , and is located in the <code>eclipse</code> sub-directory of the install. If installed at
       <code>c:\eclipse-SDK-4.32-win64</code> , the executable is <code>c:\eclipse-SDK-4.32-win64\eclipse\eclipse.exe</code> . <b>Note:</b> Set-up on most other operating environments is analogous.
       Special instructions for Mac OS X are listed
     </a><a href="#macosx">below</a>.


### PR DESCRIPTION
Fixes #186 by:
* Pointing the "target environment" and "plug-in porting guide" page links to their 4.32 versions, instead of 4.31.
* Mentioning that while the platform does work with a Java 17 VM, the IDE does require Java 21.

There is an additional problem, but it is not trivial: the "porting guide" mentioned does not exist, and neither do the corresponding pages for recent versions. The latest version of that guide is from v4.24, I think, so either the paragraphs in questions should be changed or removed entirely.