### PR TITLE
Fix release notes and project plan broken links (4.6-4.32)

### DIFF
--- a/development/plans/eclipse_project_plan_4.30.xml
+++ b/development/plans/eclipse_project_plan_4.30.xml
@@ -339,7 +339,7 @@ compared to bugs which are reproducible on the target environments listed above.
 
 <p><strong>API Contract Compatibility:</strong> Eclipse SDK 4.30 will be upwards
   contract-compatible with Eclipse SDK 4.29 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_30_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_30_porting_guide.html" target="_top">
     <em>Eclipse 4.30 Plug-in Migration Guide</em>
   </a>. Programs that use affected APIs and extension points will need to be ported
   to Eclipse SDK 4.30 APIs. Downward contract compatibility
@@ -351,7 +351,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.30 will be upwards
   binary-compatible with Eclipse SDK 4.29 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_30_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_30_porting_guide.html" target="_top">
     <em>Eclipse 4.30 Plug-in Migration Guide</em>
   </a>. Downward plug-in compatibility is not supported. Plug-ins for Eclipse SDK
   4.30 will not be usable in Eclipse SDK 4.29. Refer to
@@ -361,7 +361,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Source Compatibility:</strong> Eclipse SDK 4.30 will be upwards source-compatible
   with Eclipse SDK 4.29 except in the areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_30_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_30_porting_guide.html" target="_top">
     <em>Eclipse 4.30 Plug-in Migration Guide</em>
   </a>. This means that source files written
   to use Eclipse SDK 4.30 APIs might successfully compile and run against Eclipse

--- a/development/plans/eclipse_project_plan_4_25.xml
+++ b/development/plans/eclipse_project_plan_4_25.xml
@@ -339,7 +339,7 @@ compared to bugs which are reproducible on the target environments listed above.
 
 <p><strong>API Contract Compatibility:</strong> Eclipse SDK 4.25 will be upwards
   contract-compatible with Eclipse SDK 4.24 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_25_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2022-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_25_porting_guide.html" target="_top">
     <em>Eclipse 4.25 Plug-in Migration Guide</em>
   </a>. Programs that use affected APIs and extension points will need to be ported
   to Eclipse SDK 4.25 APIs. Downward contract compatibility
@@ -351,7 +351,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.25 will be upwards
   binary-compatible with Eclipse SDK 4.24 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_25_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2022-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_25_porting_guide.html" target="_top">
     <em>Eclipse 4.25 Plug-in Migration Guide</em>
   </a>. Downward plug-in compatibility is not supported. Plug-ins for Eclipse SDK
   4.25 will not be usable in Eclipse SDK 4.24. Refer to
@@ -361,7 +361,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Source Compatibility:</strong> Eclipse SDK 4.25 will be upwards source-compatible
   with Eclipse SDK 4.24 except in the areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_25_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2022-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_25_porting_guide.html" target="_top">
     <em>Eclipse 4.25 Plug-in Migration Guide</em>
   </a>. This means that source files written
   to use Eclipse SDK 4.25 APIs might successfully compile and run against Eclipse

--- a/development/plans/eclipse_project_plan_4_26.xml
+++ b/development/plans/eclipse_project_plan_4_26.xml
@@ -338,7 +338,7 @@ compared to bugs which are reproducible on the target environments listed above.
 
 <p><strong>API Contract Compatibility:</strong> Eclipse SDK 4.26 will be upwards
   contract-compatible with Eclipse SDK 4.25 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_26_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2022-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_26_porting_guide.html" target="_top">
     <em>Eclipse 4.26 Plug-in Migration Guide</em>
   </a>. Programs that use affected APIs and extension points will need to be ported
   to Eclipse SDK 4.26 APIs. Downward contract compatibility
@@ -350,7 +350,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.26 will be upwards
   binary-compatible with Eclipse SDK 4.25 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_26_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2022-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_26_porting_guide.html" target="_top">
     <em>Eclipse 4.26 Plug-in Migration Guide</em>
   </a>. Downward plug-in compatibility is not supported. Plug-ins for Eclipse SDK
   4.26 will not be usable in Eclipse SDK 4.25. Refer to
@@ -360,7 +360,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Source Compatibility:</strong> Eclipse SDK 4.26 will be upwards source-compatible
   with Eclipse SDK 4.25 except in the areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_26_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2022-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_26_porting_guide.html" target="_top">
     <em>Eclipse 4.26 Plug-in Migration Guide</em>
   </a>. This means that source files written
   to use Eclipse SDK 4.26 APIs might successfully compile and run against Eclipse

--- a/development/plans/eclipse_project_plan_4_27.xml
+++ b/development/plans/eclipse_project_plan_4_27.xml
@@ -328,7 +328,7 @@ compared to bugs which are reproducible on the target environments listed above.
 
 <p><strong>API Contract Compatibility:</strong> Eclipse SDK 4.27 will be upwards
   contract-compatible with Eclipse SDK 4.26 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_27_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_27_porting_guide.html" target="_top">
     <em>Eclipse 4.27 Plug-in Migration Guide</em>
   </a>. Programs that use affected APIs and extension points will need to be ported
   to Eclipse SDK 4.27 APIs. Downward contract compatibility
@@ -340,7 +340,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.27 will be upwards
   binary-compatible with Eclipse SDK 4.26 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_27_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_27_porting_guide.html" target="_top">
     <em>Eclipse 4.27 Plug-in Migration Guide</em>
   </a>. Downward plug-in compatibility is not supported. Plug-ins for Eclipse SDK
   4.27 will not be usable in Eclipse SDK 4.26. Refer to
@@ -350,7 +350,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Source Compatibility:</strong> Eclipse SDK 4.27 will be upwards source-compatible
   with Eclipse SDK 4.26 except in the areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_27_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_27_porting_guide.html" target="_top">
     <em>Eclipse 4.27 Plug-in Migration Guide</em>
   </a>. This means that source files written
   to use Eclipse SDK 4.27 APIs might successfully compile and run against Eclipse

--- a/development/plans/eclipse_project_plan_4_28.xml
+++ b/development/plans/eclipse_project_plan_4_28.xml
@@ -328,7 +328,7 @@ compared to bugs which are reproducible on the target environments listed above.
 
 <p><strong>API Contract Compatibility:</strong> Eclipse SDK 4.28 will be upwards
   contract-compatible with Eclipse SDK 4.27 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_28_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_28_porting_guide.html" target="_top">
     <em>Eclipse 4.28 Plug-in Migration Guide</em>
   </a>. Programs that use affected APIs and extension points will need to be ported
   to Eclipse SDK 4.28 APIs. Downward contract compatibility
@@ -340,7 +340,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.28 will be upwards
   binary-compatible with Eclipse SDK 4.27 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_28_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_28_porting_guide.html" target="_top">
     <em>Eclipse 4.28 Plug-in Migration Guide</em>
   </a>. Downward plug-in compatibility is not supported. Plug-ins for Eclipse SDK
   4.28 will not be usable in Eclipse SDK 4.27. Refer to
@@ -350,7 +350,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Source Compatibility:</strong> Eclipse SDK 4.28 will be upwards source-compatible
   with Eclipse SDK 4.27 except in the areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_28_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_28_porting_guide.html" target="_top">
     <em>Eclipse 4.28 Plug-in Migration Guide</em>
   </a>. This means that source files written
   to use Eclipse SDK 4.28 APIs might successfully compile and run against Eclipse

--- a/development/plans/eclipse_project_plan_4_29.xml
+++ b/development/plans/eclipse_project_plan_4_29.xml
@@ -328,7 +328,7 @@ compared to bugs which are reproducible on the target environments listed above.
 
 <p><strong>API Contract Compatibility:</strong> Eclipse SDK 4.29 will be upwards
   contract-compatible with Eclipse SDK 4.28 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_29_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_29_porting_guide.html" target="_top">
     <em>Eclipse 4.29 Plug-in Migration Guide</em>
   </a>. Programs that use affected APIs and extension points will need to be ported
   to Eclipse SDK 4.29 APIs. Downward contract compatibility
@@ -340,7 +340,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.29 will be upwards
   binary-compatible with Eclipse SDK 4.28 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_29_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_29_porting_guide.html" target="_top">
     <em>Eclipse 4.29 Plug-in Migration Guide</em>
   </a>. Downward plug-in compatibility is not supported. Plug-ins for Eclipse SDK
   4.29 will not be usable in Eclipse SDK 4.28. Refer to
@@ -350,7 +350,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Source Compatibility:</strong> Eclipse SDK 4.29 will be upwards source-compatible
   with Eclipse SDK 4.28 except in the areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_29_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2023-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_29_porting_guide.html" target="_top">
     <em>Eclipse 4.29 Plug-in Migration Guide</em>
   </a>. This means that source files written
   to use Eclipse SDK 4.29 APIs might successfully compile and run against Eclipse

--- a/development/plans/eclipse_project_plan_4_31.xml
+++ b/development/plans/eclipse_project_plan_4_31.xml
@@ -327,7 +327,7 @@ compared to bugs which are reproducible on the target environments listed above.
 
 <p><strong>API Contract Compatibility:</strong> Eclipse SDK 4.31 will be upwards
   contract-compatible with Eclipse SDK 4.30 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_31_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2024-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_31_porting_guide.html" target="_top">
     <em>Eclipse 4.31 Plug-in Migration Guide</em>
   </a>. Programs that use affected APIs and extension points will need to be ported
   to Eclipse SDK 4.31 APIs. Downward contract compatibility
@@ -339,7 +339,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.31 will be upwards
   binary-compatible with Eclipse SDK 4.30 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_31_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2024-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_31_porting_guide.html" target="_top">
     <em>Eclipse 4.31 Plug-in Migration Guide</em>
   </a>. Downward plug-in compatibility is not supported. Plug-ins for Eclipse SDK
   4.31 will not be usable in Eclipse SDK 4.30. Refer to
@@ -349,7 +349,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Source Compatibility:</strong> Eclipse SDK 4.31 will be upwards source-compatible
   with Eclipse SDK 4.30 except in the areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_31_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2024-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_31_porting_guide.html" target="_top">
     <em>Eclipse 4.31 Plug-in Migration Guide</em>
   </a>. This means that source files written
   to use Eclipse SDK 4.31 APIs might successfully compile and run against Eclipse

--- a/development/plans/eclipse_project_plan_4_32.xml
+++ b/development/plans/eclipse_project_plan_4_32.xml
@@ -327,7 +327,7 @@ compared to bugs which are reproducible on the target environments listed above.
 
 <p><strong>API Contract Compatibility:</strong> Eclipse SDK 4.32 will be upwards
   contract-compatible with Eclipse SDK 4.31 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_32_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2024-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_32_porting_guide.html" target="_top">
     <em>Eclipse 4.32 Plug-in Migration Guide</em>
   </a>. Programs that use affected APIs and extension points will need to be ported
   to Eclipse SDK 4.32 APIs. Downward contract compatibility
@@ -339,7 +339,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.32 will be upwards
   binary-compatible with Eclipse SDK 4.31 except in those areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_32_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2024-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_32_porting_guide.html" target="_top">
     <em>Eclipse 4.32 Plug-in Migration Guide</em>
   </a>. Downward plug-in compatibility is not supported. Plug-ins for Eclipse SDK
   4.32 will not be usable in Eclipse SDK 4.31. Refer to
@@ -349,7 +349,7 @@ compared to bugs which are reproducible on the target environments listed above.
   
 <p><strong>Source Compatibility:</strong> Eclipse SDK 4.32 will be upwards source-compatible
   with Eclipse SDK 4.31 except in the areas noted in the
-  <a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_32_porting_guide.html" target="_top">
+  <a href="https://help.eclipse.org/2024-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_32_porting_guide.html" target="_top">
     <em>Eclipse 4.32 Plug-in Migration Guide</em>
   </a>. This means that source files written
   to use Eclipse SDK 4.32 APIs might successfully compile and run against Eclipse

--- a/development/readme_eclipse_4.10.html
+++ b/development/readme_eclipse_4.10.html
@@ -179,7 +179,6 @@ after the release.
                 <li><a href="#mozTocId574781">Using Eclipse 4.10 to develop plug-ins that work in Eclipse 4.9</a></li>
               </ol></li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
       </ol></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
@@ -192,9 +191,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.10 release of the Eclipse Project is developed on Java SE 8 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1731,22 +1727,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_10.xml#appendix">Eclipse 4.10 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.11.html
+++ b/development/readme_eclipse_4.11.html
@@ -178,7 +178,6 @@ after the release.
                 <li><a href="#mozTocId574781">Using Eclipse 4.11 to develop plug-ins that work in Eclipse 4.10</a></li>
               </ol></li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
       </ol></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
@@ -191,9 +190,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.11 release of the Eclipse Project is developed on Java SE 8 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1720,22 +1716,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_11.xml#appendix">Eclipse 4.11 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.12.html
+++ b/development/readme_eclipse_4.12.html
@@ -179,7 +179,6 @@ after the release.
               </ol>
             </li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
     <a
@@ -191,9 +190,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.12 release of the Eclipse Project is developed on Java SE 8 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1720,22 +1716,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_12.xml#appendix">Eclipse 4.12 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.13.html
+++ b/development/readme_eclipse_4.13.html
@@ -179,7 +179,6 @@ after the release.
               </ol>
             </li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
     <a
@@ -191,9 +190,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.13 release of the Eclipse Project is developed on Java SE 8 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1720,22 +1716,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_13.xml#appendix">Eclipse 4.13 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.14.html
+++ b/development/readme_eclipse_4.14.html
@@ -179,7 +179,6 @@ after the release.
               </ol>
             </li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
     <a
@@ -191,9 +190,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.14 release of the Eclipse Project is developed on Java SE 8 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1720,22 +1716,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_14.xml#appendix">Eclipse 4.14 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.15.html
+++ b/development/readme_eclipse_4.15.html
@@ -180,7 +180,6 @@ after the release.
               </ol>
             </li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
     <a
@@ -192,9 +191,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.15 release of the Eclipse Project is developed on Java SE 8 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1734,22 +1730,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_15.xml#appendix">Eclipse 4.15 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.16.html
+++ b/development/readme_eclipse_4.16.html
@@ -179,7 +179,6 @@ after the release.
               </ol>
             </li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
     <a
@@ -191,9 +190,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.16 release of the Eclipse Project is developed on Java SE 8 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1720,22 +1716,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_16.xml#appendix">Eclipse 4.16 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.17.html
+++ b/development/readme_eclipse_4.17.html
@@ -179,7 +179,6 @@ after the release.
               </ol>
             </li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
     <a
@@ -191,9 +190,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.17 release of the Eclipse Project is developed on Java SE 11 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1720,22 +1716,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_17.xml#appendix">Eclipse 4.17 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.18.html
+++ b/development/readme_eclipse_4.18.html
@@ -181,7 +181,6 @@ after the release.
               </ol>
             </li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
     <a
@@ -193,9 +192,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.18 release of the Eclipse Project is developed on Java SE 11 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1665,22 +1661,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_18.xml#appendix">Eclipse 4.18 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.19.html
+++ b/development/readme_eclipse_4.19.html
@@ -180,7 +180,6 @@ after the release.
               </ol>
             </li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
     <a
@@ -192,9 +191,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.19 release of the Eclipse Project is developed on Java SE 11 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1654,22 +1650,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_19.xml#appendix">Eclipse 4.19 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.20.html
+++ b/development/readme_eclipse_4.20.html
@@ -180,7 +180,6 @@ after the release.
               </ol>
             </li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
     <a
@@ -192,9 +191,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.20 release of the Eclipse Project is developed on Java SE 11 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1654,22 +1650,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_20.xml#appendix">Eclipse 4.20 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.21.html
+++ b/development/readme_eclipse_4.21.html
@@ -180,7 +180,6 @@ after the release.
               </ol>
             </li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
     <a
@@ -192,9 +191,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.21 release of the Eclipse Project is developed on Java SE 11 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1654,22 +1650,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=https://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_21.xml#appendix">Eclipse 4.21 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.22.html
+++ b/development/readme_eclipse_4.22.html
@@ -169,7 +169,6 @@ after the release.
               </ol>
             </li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
     <a
@@ -181,9 +180,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.22 release of the Eclipse Project is developed on Java SE 11 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically

--- a/development/readme_eclipse_4.23.html
+++ b/development/readme_eclipse_4.23.html
@@ -178,9 +178,6 @@ after the release.
     5, etc).</p>
   <p>In general, the 4.23 release of the Eclipse Project is developed on Java SE 11 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
   <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
-  <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
     test them we cannot vouch for them. Problems encountered when running Eclipse on a non-reference platform that cannot be recreated on any reference platform will be given lower priority than

--- a/development/readme_eclipse_4.24.html
+++ b/development/readme_eclipse_4.24.html
@@ -178,9 +178,6 @@ after the release.
     5, etc).</p>
   <p>In general, the 4.24 release of the Eclipse Project is developed on Java SE 11 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
   <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
-  <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
     test them we cannot vouch for them. Problems encountered when running Eclipse on a non-reference platform that cannot be recreated on any reference platform will be given lower priority than

--- a/development/readme_eclipse_4.25.html
+++ b/development/readme_eclipse_4.25.html
@@ -178,9 +178,6 @@ after the release.
     5, etc).</p>
   <p>In general, the 4.25 release of the Eclipse Project is developed on Java SE 11 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
   <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
-  <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
     test them we cannot vouch for them. Problems encountered when running Eclipse on a non-reference platform that cannot be recreated on any reference platform will be given lower priority than

--- a/development/readme_eclipse_4.25.html
+++ b/development/readme_eclipse_4.25.html
@@ -219,20 +219,20 @@ after the release.
     <a
       class="mozTocH3"
       name="mozTocId324309"> <strong>API Contract Compatibility:</strong> Eclipse SDK 4.25 is upwards contract-compatible with Eclipse SDK 4.24 except in those areas noted in the
-    </a><a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_25_porting_guide.html"><em>Eclipse 4.25 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
+    </a><a href="https://help.eclipse.org/2022-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_25_porting_guide.html"><em>Eclipse 4.25 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
     will need to be ported to Eclipse SDK 4.25 APIs. Downward contract compatibility is not supported. There is no guarantee that compliance with Eclipse SDK 4.25 APIs would ensure compliance with
     Eclipse SDK 4.24 APIs. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"><em>Evolving Java-based APIs</em></a> for a discussion of the kinds of API changes that maintain contract
     compatibility.
   </p>
   <p>
     <strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.25 is upwards binary-compatible with Eclipse SDK 4.24 except in those areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_25_porting_guide.html"><em>Eclipse 4.25 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
+      href="https://help.eclipse.org/2022-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_25_porting_guide.html"><em>Eclipse 4.25 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
     Plug-ins for Eclipse SDK 4.25 will not be usable in Eclipse SDK 4.24. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"> <em>Evolving Java-based APIs</em></a> for a discussion of
     the kinds of API changes that maintain binary compatibility.
   </p>
   <p>
     <strong>Source Compatibility:</strong> Eclipse SDK 4.25 is upwards source-compatible with Eclipse SDK 4.24 except in the areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_25_porting_guide.html"><em>Eclipse 4.25 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
+      href="https://help.eclipse.org/2022-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_25_porting_guide.html"><em>Eclipse 4.25 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
     SDK 4.25 APIs might successfully compile and run against Eclipse SDK 4.24 APIs, although this is not guaranteed. Downward source compatibility is not supported. If source files use new Eclipse SDK
     APIs, they will not be usable with an earlier version of the Eclipse SDK.
   </p>

--- a/development/readme_eclipse_4.26.html
+++ b/development/readme_eclipse_4.26.html
@@ -219,20 +219,20 @@ after the release.
     <a
       class="mozTocH3"
       name="mozTocId324309"> <strong>API Contract Compatibility:</strong> Eclipse SDK 4.26 is upwards contract-compatible with Eclipse SDK 4.25 except in those areas noted in the
-    </a><a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_26_porting_guide.html"><em>Eclipse 4.26 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
+    </a><a href="https://help.eclipse.org/2022-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_26_porting_guide.html"><em>Eclipse 4.26 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
     will need to be ported to Eclipse SDK 4.26 APIs. Downward contract compatibility is not supported. There is no guarantee that compliance with Eclipse SDK 4.26 APIs would ensure compliance with
     Eclipse SDK 4.25 APIs. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"><em>Evolving Java-based APIs</em></a> for a discussion of the kinds of API changes that maintain contract
     compatibility.
   </p>
   <p>
     <strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.26 is upwards binary-compatible with Eclipse SDK 4.25 except in those areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_26_porting_guide.html"><em>Eclipse 4.26 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
+      href="https://help.eclipse.org/2022-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_26_porting_guide.html"><em>Eclipse 4.26 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
     Plug-ins for Eclipse SDK 4.26 will not be usable in Eclipse SDK 4.25. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"> <em>Evolving Java-based APIs</em></a> for a discussion of
     the kinds of API changes that maintain binary compatibility.
   </p>
   <p>
     <strong>Source Compatibility:</strong> Eclipse SDK 4.26 is upwards source-compatible with Eclipse SDK 4.25 except in the areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_26_porting_guide.html"><em>Eclipse 4.26 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
+      href="https://help.eclipse.org/2022-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_26_porting_guide.html"><em>Eclipse 4.26 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
     SDK 4.26 APIs might successfully compile and run against Eclipse SDK 4.25 APIs, although this is not guaranteed. Downward source compatibility is not supported. If source files use new Eclipse SDK
     APIs, they will not be usable with an earlier version of the Eclipse SDK.
   </p>

--- a/development/readme_eclipse_4.26.html
+++ b/development/readme_eclipse_4.26.html
@@ -178,9 +178,6 @@ after the release.
     5, etc).</p>
   <p>In general, the 4.26 release of the Eclipse Project is developed on Java SE 11 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
   <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
-  <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
     test them we cannot vouch for them. Problems encountered when running Eclipse on a non-reference platform that cannot be recreated on any reference platform will be given lower priority than

--- a/development/readme_eclipse_4.27.html
+++ b/development/readme_eclipse_4.27.html
@@ -219,20 +219,20 @@ after the release.
     <a
       class="mozTocH3"
       name="mozTocId324309"> <strong>API Contract Compatibility:</strong> Eclipse SDK 4.27 is upwards contract-compatible with Eclipse SDK 4.26 except in those areas noted in the
-    </a><a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_27_porting_guide.html"><em>Eclipse 4.27 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
+    </a><a href="https://help.eclipse.org/2023-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_27_porting_guide.html"><em>Eclipse 4.27 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
     will need to be ported to Eclipse SDK 4.27 APIs. Downward contract compatibility is not supported. There is no guarantee that compliance with Eclipse SDK 4.27 APIs would ensure compliance with
     Eclipse SDK 4.26 APIs. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"><em>Evolving Java-based APIs</em></a> for a discussion of the kinds of API changes that maintain contract
     compatibility.
   </p>
   <p>
     <strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.27 is upwards binary-compatible with Eclipse SDK 4.26 except in those areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_27_porting_guide.html"><em>Eclipse 4.27 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
+      href="https://help.eclipse.org/2023-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_27_porting_guide.html"><em>Eclipse 4.27 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
     Plug-ins for Eclipse SDK 4.27 will not be usable in Eclipse SDK 4.26. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"> <em>Evolving Java-based APIs</em></a> for a discussion of
     the kinds of API changes that maintain binary compatibility.
   </p>
   <p>
     <strong>Source Compatibility:</strong> Eclipse SDK 4.27 is upwards source-compatible with Eclipse SDK 4.26 except in the areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_27_porting_guide.html"><em>Eclipse 4.27 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
+      href="https://help.eclipse.org/2023-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_27_porting_guide.html"><em>Eclipse 4.27 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
     SDK 4.27 APIs might successfully compile and run against Eclipse SDK 4.26 APIs, although this is not guaranteed. Downward source compatibility is not supported. If source files use new Eclipse SDK
     APIs, they will not be usable with an earlier version of the Eclipse SDK.
   </p>

--- a/development/readme_eclipse_4.27.html
+++ b/development/readme_eclipse_4.27.html
@@ -178,9 +178,6 @@ after the release.
     5, etc).</p>
   <p>In general, the 4.27 release of the Eclipse Project is developed on Java SE 11 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
   <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
-  <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
     test them we cannot vouch for them. Problems encountered when running Eclipse on a non-reference platform that cannot be recreated on any reference platform will be given lower priority than

--- a/development/readme_eclipse_4.28.html
+++ b/development/readme_eclipse_4.28.html
@@ -219,20 +219,20 @@ after the release.
     <a
       class="mozTocH3"
       name="mozTocId324309"> <strong>API Contract Compatibility:</strong> Eclipse SDK 4.28 is upwards contract-compatible with Eclipse SDK 4.27 except in those areas noted in the
-    </a><a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_28_porting_guide.html"><em>Eclipse 4.28 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
+    </a><a href="https://help.eclipse.org/2023-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_28_porting_guide.html"><em>Eclipse 4.28 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
     will need to be ported to Eclipse SDK 4.28 APIs. Downward contract compatibility is not supported. There is no guarantee that compliance with Eclipse SDK 4.28 APIs would ensure compliance with
     Eclipse SDK 4.27 APIs. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"><em>Evolving Java-based APIs</em></a> for a discussion of the kinds of API changes that maintain contract
     compatibility.
   </p>
   <p>
     <strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.28 is upwards binary-compatible with Eclipse SDK 4.27 except in those areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_28_porting_guide.html"><em>Eclipse 4.28 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
+      href="https://help.eclipse.org/2023-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_28_porting_guide.html"><em>Eclipse 4.28 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
     Plug-ins for Eclipse SDK 4.28 will not be usable in Eclipse SDK 4.27. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"> <em>Evolving Java-based APIs</em></a> for a discussion of
     the kinds of API changes that maintain binary compatibility.
   </p>
   <p>
     <strong>Source Compatibility:</strong> Eclipse SDK 4.28 is upwards source-compatible with Eclipse SDK 4.27 except in the areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_28_porting_guide.html"><em>Eclipse 4.28 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
+      href="https://help.eclipse.org/2023-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_28_porting_guide.html"><em>Eclipse 4.28 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
     SDK 4.28 APIs might successfully compile and run against Eclipse SDK 4.27 APIs, although this is not guaranteed. Downward source compatibility is not supported. If source files use new Eclipse SDK
     APIs, they will not be usable with an earlier version of the Eclipse SDK.
   </p>

--- a/development/readme_eclipse_4.28.html
+++ b/development/readme_eclipse_4.28.html
@@ -178,9 +178,6 @@ after the release.
     5, etc).</p>
   <p>In general, the 4.28 release of the Eclipse Project is developed on Java SE 17 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
   <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
-  <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
     test them we cannot vouch for them. Problems encountered when running Eclipse on a non-reference platform that cannot be recreated on any reference platform will be given lower priority than

--- a/development/readme_eclipse_4.29.html
+++ b/development/readme_eclipse_4.29.html
@@ -219,20 +219,20 @@ after the release.
     <a
       class="mozTocH3"
       name="mozTocId324309"> <strong>API Contract Compatibility:</strong> Eclipse SDK 4.29 is upwards contract-compatible with Eclipse SDK 4.28 except in those areas noted in the
-    </a><a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_29_porting_guide.html"><em>Eclipse 4.29 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
+    </a><a href="https://help.eclipse.org/2023-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_29_porting_guide.html"><em>Eclipse 4.29 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
     will need to be ported to Eclipse SDK 4.29 APIs. Downward contract compatibility is not supported. There is no guarantee that compliance with Eclipse SDK 4.29 APIs would ensure compliance with
     Eclipse SDK 4.28 APIs. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"><em>Evolving Java-based APIs</em></a> for a discussion of the kinds of API changes that maintain contract
     compatibility.
   </p>
   <p>
     <strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.29 is upwards binary-compatible with Eclipse SDK 4.28 except in those areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_29_porting_guide.html"><em>Eclipse 4.29 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
+      href="https://help.eclipse.org/2023-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_29_porting_guide.html"><em>Eclipse 4.29 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
     Plug-ins for Eclipse SDK 4.29 will not be usable in Eclipse SDK 4.28. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"> <em>Evolving Java-based APIs</em></a> for a discussion of
     the kinds of API changes that maintain binary compatibility.
   </p>
   <p>
     <strong>Source Compatibility:</strong> Eclipse SDK 4.29 is upwards source-compatible with Eclipse SDK 4.28 except in the areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_29_porting_guide.html"><em>Eclipse 4.29 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
+      href="https://help.eclipse.org/2023-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_29_porting_guide.html"><em>Eclipse 4.29 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
     SDK 4.29 APIs might successfully compile and run against Eclipse SDK 4.28 APIs, although this is not guaranteed. Downward source compatibility is not supported. If source files use new Eclipse SDK
     APIs, they will not be usable with an earlier version of the Eclipse SDK.
   </p>

--- a/development/readme_eclipse_4.29.html
+++ b/development/readme_eclipse_4.29.html
@@ -178,9 +178,6 @@ after the release.
     5, etc).</p>
   <p>In general, the 4.29 release of the Eclipse Project is developed on Java SE 17 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
   <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
-  <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
     test them we cannot vouch for them. Problems encountered when running Eclipse on a non-reference platform that cannot be recreated on any reference platform will be given lower priority than

--- a/development/readme_eclipse_4.30.html
+++ b/development/readme_eclipse_4.30.html
@@ -178,9 +178,6 @@ after the release.
     5, etc).</p>
   <p>In general, the 4.30 release of the Eclipse Project is developed on Java SE 17 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
   <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
-  <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
     test them we cannot vouch for them. Problems encountered when running Eclipse on a non-reference platform that cannot be recreated on any reference platform will be given lower priority than

--- a/development/readme_eclipse_4.30.html
+++ b/development/readme_eclipse_4.30.html
@@ -219,20 +219,20 @@ after the release.
     <a
       class="mozTocH3"
       name="mozTocId324309"> <strong>API Contract Compatibility:</strong> Eclipse SDK 4.30 is upwards contract-compatible with Eclipse SDK 4.29 except in those areas noted in the
-    </a><a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_30_porting_guide.html"><em>Eclipse 4.30 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
+    </a><a href="https://help.eclipse.org/2023-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_30_porting_guide.html"><em>Eclipse 4.30 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
     will need to be ported to Eclipse SDK 4.30 APIs. Downward contract compatibility is not supported. There is no guarantee that compliance with Eclipse SDK 4.30 APIs would ensure compliance with
     Eclipse SDK 4.29 APIs. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"><em>Evolving Java-based APIs</em></a> for a discussion of the kinds of API changes that maintain contract
     compatibility.
   </p>
   <p>
     <strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.30 is upwards binary-compatible with Eclipse SDK 4.29 except in those areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_30_porting_guide.html"><em>Eclipse 4.30 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
+      href="https://help.eclipse.org/2023-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_30_porting_guide.html"><em>Eclipse 4.30 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
     Plug-ins for Eclipse SDK 4.30 will not be usable in Eclipse SDK 4.29. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"> <em>Evolving Java-based APIs</em></a> for a discussion of
     the kinds of API changes that maintain binary compatibility.
   </p>
   <p>
     <strong>Source Compatibility:</strong> Eclipse SDK 4.30 is upwards source-compatible with Eclipse SDK 4.29 except in the areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_30_porting_guide.html"><em>Eclipse 4.30 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
+      href="https://help.eclipse.org/2023-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_30_porting_guide.html"><em>Eclipse 4.30 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
     SDK 4.30 APIs might successfully compile and run against Eclipse SDK 4.29 APIs, although this is not guaranteed. Downward source compatibility is not supported. If source files use new Eclipse SDK
     APIs, they will not be usable with an earlier version of the Eclipse SDK.
   </p>

--- a/development/readme_eclipse_4.31.html
+++ b/development/readme_eclipse_4.31.html
@@ -219,20 +219,20 @@ after the release.
     <a
       class="mozTocH3"
       name="mozTocId324309"> <strong>API Contract Compatibility:</strong> Eclipse SDK 4.31 is upwards contract-compatible with Eclipse SDK 4.30 except in those areas noted in the
-    </a><a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_31_porting_guide.html"><em>Eclipse 4.31 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
+    </a><a href="https://help.eclipse.org/2024-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_31_porting_guide.html"><em>Eclipse 4.31 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
     will need to be ported to Eclipse SDK 4.31 APIs. Downward contract compatibility is not supported. There is no guarantee that compliance with Eclipse SDK 4.31 APIs would ensure compliance with
     Eclipse SDK 4.30 APIs. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"><em>Evolving Java-based APIs</em></a> for a discussion of the kinds of API changes that maintain contract
     compatibility.
   </p>
   <p>
     <strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.31 is upwards binary-compatible with Eclipse SDK 4.30 except in those areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_31_porting_guide.html"><em>Eclipse 4.31 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
+      href="https://help.eclipse.org/2024-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_31_porting_guide.html"><em>Eclipse 4.31 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
     Plug-ins for Eclipse SDK 4.31 will not be usable in Eclipse SDK 4.30. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"> <em>Evolving Java-based APIs</em></a> for a discussion of
     the kinds of API changes that maintain binary compatibility.
   </p>
   <p>
     <strong>Source Compatibility:</strong> Eclipse SDK 4.31 is upwards source-compatible with Eclipse SDK 4.30 except in the areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_31_porting_guide.html"><em>Eclipse 4.31 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
+      href="https://help.eclipse.org/2024-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_31_porting_guide.html"><em>Eclipse 4.31 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
     SDK 4.31 APIs might successfully compile and run against Eclipse SDK 4.30 APIs, although this is not guaranteed. Downward source compatibility is not supported. If source files use new Eclipse SDK
     APIs, they will not be usable with an earlier version of the Eclipse SDK.
   </p>

--- a/development/readme_eclipse_4.31.html
+++ b/development/readme_eclipse_4.31.html
@@ -178,9 +178,6 @@ after the release.
     5, etc).</p>
   <p>In general, the 4.31 release of the Eclipse Project is developed on Java SE 17 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
   <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
-  <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
     test them we cannot vouch for them. Problems encountered when running Eclipse on a non-reference platform that cannot be recreated on any reference platform will be given lower priority than

--- a/development/readme_eclipse_4.32.html
+++ b/development/readme_eclipse_4.32.html
@@ -219,20 +219,20 @@ after the release.
     <a
       class="mozTocH3"
       name="mozTocId324309"> <strong>API Contract Compatibility:</strong> Eclipse SDK 4.32 is upwards contract-compatible with Eclipse SDK 4.31 except in those areas noted in the
-    </a><a href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_32_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
+    </a><a href="https://help.eclipse.org/2024-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_32_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em></a>. Programs that use affected APIs and extension points
     will need to be ported to Eclipse SDK 4.32 APIs. Downward contract compatibility is not supported. There is no guarantee that compliance with Eclipse SDK 4.32 APIs would ensure compliance with
     Eclipse SDK 4.31 APIs. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"><em>Evolving Java-based APIs</em></a> for a discussion of the kinds of API changes that maintain contract
     compatibility.
   </p>
   <p>
     <strong>Binary (plug-in) Compatibility:</strong> Eclipse SDK 4.32 is upwards binary-compatible with Eclipse SDK 4.31 except in those areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_32_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
+      href="https://help.eclipse.org/2024-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_32_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em> </a>. Downward plug-in compatibility is not supported.
     Plug-ins for Eclipse SDK 4.32 will not be usable in Eclipse SDK 4.31. Refer to <a href="https://wiki.eclipse.org/Evolving_Java-based_APIs"> <em>Evolving Java-based APIs</em></a> for a discussion of
     the kinds of API changes that maintain binary compatibility.
   </p>
   <p>
     <strong>Source Compatibility:</strong> Eclipse SDK 4.32 is upwards source-compatible with Eclipse SDK 4.31 except in the areas noted in the <a
-      href="https://www.eclipse.org/eclipse/development/porting/eclipse_4_32_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
+      href="https://help.eclipse.org/2024-06/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_32_porting_guide.html"><em>Eclipse 4.32 Plug-in Migration Guide</em> </a>. This means that source files written to use Eclipse
     SDK 4.32 APIs might successfully compile and run against Eclipse SDK 4.31 APIs, although this is not guaranteed. Downward source compatibility is not supported. If source files use new Eclipse SDK
     APIs, they will not be usable with an earlier version of the Eclipse SDK.
   </p>

--- a/development/readme_eclipse_4.6.html
+++ b/development/readme_eclipse_4.6.html
@@ -197,7 +197,6 @@ after the release.
                 <li><a href="#mozTocId574781">Using Eclipse 4.6 to develop plug-ins that work in Eclipse 4.5</a></li>
               </ol></li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
       </ol></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
@@ -210,9 +209,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.6 release of the Eclipse Project is developed on Java SE 8 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1845,22 +1841,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_6.xml#appendix">Eclipse 4.6 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.7.html
+++ b/development/readme_eclipse_4.7.html
@@ -189,7 +189,6 @@ after the release.
                 <li><a href="#mozTocId574781">Using Eclipse 4.7 to develop plug-ins that work in Eclipse 4.6</a></li>
               </ol></li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
       </ol></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
@@ -202,9 +201,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.7 release of the Eclipse Project is developed on Java SE 8 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1743,22 +1739,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_7.xml#appendix">Eclipse 4.7 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.8.html
+++ b/development/readme_eclipse_4.8.html
@@ -189,7 +189,6 @@ after the release.
                 <li><a href="#mozTocId574781">Using Eclipse 4.8 to develop plug-ins that work in Eclipse 4.7</a></li>
               </ol></li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
       </ol></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
@@ -202,9 +201,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.8 release of the Eclipse Project is developed on Java SE 8 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1749,22 +1745,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_8.xml#appendix">Eclipse 4.8 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>

--- a/development/readme_eclipse_4.9.html
+++ b/development/readme_eclipse_4.9.html
@@ -178,7 +178,6 @@ after the release.
                 <li><a href="#mozTocId574781">Using Eclipse 4.9 to develop plug-ins that work in Eclipse 4.8</a></li>
               </ol></li>
           </ol></li>
-        <li><a href="#mozTocId317294">Appendix: Execution Environment by Bundle</a></li>
       </ol></li>
   </ol>
   <h2 id="TargetOperatingEnvironments2">
@@ -191,9 +190,6 @@ after the release.
     targeted to specific classes of operating environments, requiring their source code to only reference facilities available in particular class libraries (e.g. J2ME Foundation 1.1, J2SE 1.4, Java
     5, etc).</p>
   <p>In general, the 4.9 release of the Eclipse Project is developed on Java SE 8 VMs. As such, the Eclipse SDK as a whole is targeted at all modern, desktop Java VMs.</p>
-  <p>
-    <a href="#appendix">Appendix 1</a> contains a table that indicates the class library level required for each bundle.
-  </p>
   <p>
     There are many different implementations of the Java Platform running atop a variety of operating systems. We focus our testing on a handful of popular combinations of operating system and Java
     Platform; these are our <em>reference platforms</em>. Eclipse undoubtedly runs fine in many operating environments beyond the reference platforms we test. However, since we do not systematically
@@ -1738,22 +1734,6 @@ after the release.
       extension points, and plug-ins. (The above list of concerns do not apply since they affect the layout and interpretation of files in the plug-in <i>project</i> but none affect the actual
       deployed form of the plug-in.)
     </a>
-  </p>
-  <h2 id="appendix">
-    <a
-      class="mozTocH2"
-      name="mozTocId317294">Appendix: Execution Environment by Bundle</a>
-  </h2>
-  <!--
-     Remember, the URL to appendix link must be full URL, since some may be
-     viewing this file, from a "file://" URL
--->
-  <p>
-    <a
-      class="mozTocH2"
-      name="mozTocId317294"> See the table in the </a><a
-      href="https://www.eclipse.org/projects/project-plan.php?planurl=http://www.eclipse.org/eclipse/development/plans/eclipse_project_plan_4_9.xml#appendix">Eclipse 4.9 Project Plan Appendix</a> for
-    the list of the minimum execution environment (Java class library) requirements of each bundle.
   </p>
   <hr />
   <p>Sun, Solaris, Java and all Java-based trademarks are trademarks of Oracle Corporation. in the United States, other countries, or both.</p>


### PR DESCRIPTION
As described in #188 , the Eclipse release notes pages (and project plans) contain links to the following pages:
* "Plug-In Migration Guide": broken from 4.24, was moved to help.eclipse.org.
*  "Appendix 1": relative to the BREE of each bundle in the platform. The release notes page links to a part of the project plan page, but that part was removed in v4.6.

This PR fixes the broken plug-in migration guides links both in the release notes and the project plans; and removes all mentions to the appendix in the affected versions.
