### PR TITLE
Fix broken XML comments

### DIFF
--- a/news/4.32/pde.html
+++ b/news/4.32/pde.html
@@ -63,7 +63,7 @@ ul {padding-left: 13px;}
   	  <p><img src="images/pde-osgi-repo-advanced-search.png" width="500"/></p>
   	  <p>If you select a bnd-style project, this is detected and shown as follows:</p>
   	  <p><img src="images/pde-osgi-repo-view-bnd.png" width="800"/></p>
-  	  <p>Additional information about this view can be found <a href="https://bndtools.org/manual/repositories-view.html">here</a>. 
+  	  <p>Additional information about this view can be found <a href="https://bndtools.org/manual/repositories-view.html">here</a>.
   	  If there are requests for more features or improvements let <a href="https://github.com/eclipse-pde/eclipse.pde/issues">us know</a>
   	  or just open a PR <a href="https://github.com/eclipse-pde/eclipse.pde/pulls">here</a>.</p>
     </td>
@@ -77,11 +77,11 @@ ul {padding-left: 13px;}
       </p>
       </td>
   </tr>
-  
+
   <!-- ******************** End of Dialogs, Wizard and Views ********************** -->
-  
+
   <!-- ******************** Editors ********************** -->
-<!--
+
   <tr>
     <td id="editors" class="section" colspan="2"><h2>Editors</h2></td>
     <!-- https://github.com/eclipse-pde/eclipse.pde/pull/1253 -->
@@ -93,7 +93,7 @@ ul {padding-left: 13px;}
       </p>
     </td>
   </tr>
--->
+
   <!-- ******************** End of Editors ********************** -->
 
   <!-- ******************** APITools ********************** -->
@@ -103,14 +103,14 @@ ul {padding-left: 13px;}
   </tr>
 -->
   <!-- ******************** End of APITools ********************** -->
-  
+
    <!-- ******************** PDE Compiler ********************** -->
 <!--
   <tr>
     <td id="pde-compiler" class="section" colspan="2"><h2>PDE Compiler</h2></td>
   </tr>
 -->
-   <!-- ******************** End of PDE Compiler ********************** --> 
+   <!-- ******************** End of PDE Compiler ********************** -->
   <tr><td colspan="2"/></tr>
 </tbody>
 </table>


### PR DESCRIPTION
A new entry and commenting out empty sections basically created a merge conflict due to being merged in reverse order of creation. Simply remove the commenting out of the section to fix the page.

fixes https://github.com/eclipse-platform/eclipse.platform/issues/1482