### PR TITLE
Fix images paths in N&N

### DIFF
--- a/news/4.34/platform.html
+++ b/news/4.34/platform.html
@@ -52,13 +52,13 @@ ul {padding-left: 13px;}
 					is not valid, a small <strong>decoration</strong> will show up and tell you that the expression is invalid.
 	          </p>
 	          <p>
-	              <img src="images\regex-improvement-decoration.png" alt="regex decoration">
+	              <img src="images/regex-improvement-decoration.png" alt="regex decoration">
 	          </p>
 			  <p>
 					If you need more information about what exactly went wrong, you can just <strong>hover</strong> over the red decoration.
 			  </p>
 			  <p>
-				<img src="images\regex-improvement-decoration-hover.png" alt="regex decoration while hovering">
+				<img src="images/regex-improvement-decoration-hover.png" alt="regex decoration while hovering">
 			  </p>
 			  <p>
 				And the best part: This feature works the same for the traditional find/replace dialog, the new overlay and the file search dialog.


### PR DESCRIPTION
In image paths, use `/` instead of `\`, otherwise images will not shown in https://eclipse.dev/eclipse/news/4.34/platform.php#improved-regex-handeling