### PR TITLE
Eclipse plug-in migration guide (porting) 4.34- bugFix

### DIFF
--- a/development/porting/eclipse_4_34_porting_guide.html
+++ b/development/porting/eclipse_4_34_porting_guide.html
@@ -5,12 +5,12 @@
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
 <meta http-equiv="Content-Style-Type" content="text/css">
 <link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
-<title>Eclipse 2024-09 (4.34) Plug-in Migration Guide</title>
+<title>Eclipse 2024-12 (4.34) Plug-in Migration Guide</title>
 </head>
 
 <body>
 
-<h1>Eclipse 2024-09 (4.34) Plug-in Migration Guide</h1>
+<h1>Eclipse 2024-12 (4.34) Plug-in Migration Guide</h1>
 <p>This guide covers migrating Eclipse 4.33 plug-ins to Eclipse 4.34.</p>
 <p>One of the goals of Eclipse 4.34 was to move Eclipse forward while remaining compatible 
   with previous versions to the greatest extent possible. That is, plug-ins written 
@@ -26,12 +26,12 @@
   These documents describe those areas and provide instructions for migrating 4.33 plug-ins to 
   4.34.</p>
 <ul>
-  <li><a href="https://help.eclipse.org/2024-09/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_34_porting_guide.html?cp=2_3_1_0">
-        Eclipse Platform 2024-09 (4.34) Plug-in Migration Guide</a></li>
-  <li><a href="https://help.eclipse.org/2024-09/topic/org.eclipse.platform.doc.isv/porting/removals.html?cp=2_3_0">
+  <li><a href="https://help.eclipse.org/2024-12/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_34_porting_guide.html?cp=2_3_1_0">
+        Eclipse Platform 2024-12 (4.34) Plug-in Migration Guide</a></li>
+  <li><a href="https://help.eclipse.org/2024-12/topic/org.eclipse.platform.doc.isv/porting/removals.html?cp=2_3_0">
         Deprecated API removals in Eclipse Platform</a></li>
-  <li><a href="https://help.eclipse.org/2024-09/topic/org.eclipse.jdt.doc.isv/porting/eclipse_4_34_porting_guide.html?cp=3_2_0_0">
-        Eclipse JDT 2024-09 (4.34) Plug-in Migration Guide</a></li>
+  <li><a href="https://help.eclipse.org/2024-12/topic/org.eclipse.jdt.doc.isv/porting/eclipse_4_34_porting_guide.html?cp=3_2_0_0">
+        Eclipse JDT 2024-12 (4.34) Plug-in Migration Guide</a></li>
 </ul>
 
 </body>


### PR DESCRIPTION
Eclipse plug-in migration guide (porting) 4.34 - BugFix