### PR TITLE
Add N&N for new image constructor

### DIFF
--- a/news/4.35/platform_isv.html
+++ b/news/4.35/platform_isv.html
@@ -43,6 +43,38 @@ ul {padding-left: 13px;}
   <!-- *********************** SWT *********************** -->
   <tr>
     <td id="SWT" class="section" colspan="2"><h2>SWT Changes</h2></td>
+    <tr id="imageConstructorGcDrawer"> <!-- https://github.com/eclipse-platform/eclipse.platform.swt/pull/1734 -->
+      <td class="title">Constructor for Dynamically Scaled, Custom-Drawn Image</td>
+      <td class="content">
+        <p>
+          The <code>Image</code> class provides a constructor for creating an empty image based on a concrete size,
+          which is then usually filled programmatically via a <code>GC</code>. Such an image will be created according to a
+          fixed zoom value. When the image is requested in a different zoom via <code>getImageData(zoom)</code>, the
+          image will be raster-scaled, leading to blurry results.
+        </p>
+        <p>
+          The API has been extended as follows to address this limitation:
+        <ul>
+          <li>
+            A new constructor has been added to the <code>Image</code> class:<br>
+            <code>Image(Device device, ImageGcDrawer imageGcDrawer, int width, int height)</code><br>
+          <li>
+            The constructor accepts implementations of <code>ImageGcDrawer</code> defining the method:<br>
+            <code>drawOn(GC gc, int imageWidth, int imageHeight)</code>
+          </li>
+        </ul>
+        </p>
+        <p>
+          Such an image will call <code>imageGcDrawer.drawOn(...)</code> whenever the image data for a different
+          zoom is requested to generate that data in a size as required for the specified zoom.
+        </p>
+        <p>
+          To be prepared for enhanced UI scaling mechanisms, such as the monitor-specific scaling feature on windows (see <a
+            href="platform.php#rescaleOnRuntimePreference">this news</a>), this new constructor should be
+          preferred for programmatic creation of images instead of the existing constructors using a fixed size.
+        </p>
+      </td>
+    </tr>
   </tr>
   <!-- *********************** End of SWT *********************** -->
   <tr><td colspan="2"/></tr>


### PR DESCRIPTION
This contributes an N&N for the new image constructor for programmatically created, dynamically scaling images as required for enhanced UI scaling mechanisms, as contributed via https://github.com/eclipse-platform/eclipse.platform.swt/pull/1734