### PR TITLE
Fix XML validation errors in news/4.35/platform.html

### DIFF
--- a/news/4.35/platform.html
+++ b/news/4.35/platform.html
@@ -42,19 +42,19 @@ ul {padding-left: 13px;}
     <td id="ViewsAndDialogs" class="section" colspan="2">
     <h2>Views, Dialogs and Toolbar </h2>
     </td>
-	<tr id="FilterByCategory">                    <!-- https://github.com/eclipse-platform/eclipse.platform.ui/pull/2579 -->
-	    <td class="title">Filter by Category</td> <!-- https://github.com/eclipse-platform/eclipse.platform.ui/pull/2602 -->
-	    <td class="content">
-	      <p>
-	      The search filter in the "Import/Export" wizard, as well as the "Show View" dialog has been extended to also support
-		  category names. On a match, all elements in the category are shown. This changes the previous behavior where only
-		  entries were matched and searching by a category would result in an empty tree.
-	      </p>
-		  <p>
-		      <img src="images/filterByCategory.png" alt="Filter import wizards by &quot;General&quot;"/>
-		  </p>
-	    </td>
-	</tr>
+  </tr>
+  <tr id="FilterByCategory">                    <!-- https://github.com/eclipse-platform/eclipse.platform.ui/pull/2579 -->
+    <td class="title">Filter by Category</td> <!-- https://github.com/eclipse-platform/eclipse.platform.ui/pull/2602 -->
+    <td class="content">
+      <p>
+        The search filter in the "Import/Export" wizard, as well as the "Show View" dialog has been extended to also support
+        category names. On a match, all elements in the category are shown. This changes the previous behavior where only
+        entries were matched and searching by a category would result in an empty tree.
+      </p>
+      <p>
+        <img src="images/filterByCategory.png" alt="Filter import wizards by &quot;General&quot;"/>
+      </p>
+    </td>
   </tr>
   <!-- ******************* End of Views, Dialogs and Toolbar ************************************* -->
 
@@ -119,7 +119,7 @@ ul {padding-left: 13px;}
         users to <b>explore this feature</b> and <b>share their feedback</b> to help us improve the functionality.
       </p>
       <p>
-        <img src="images/rescaling_setting-preference.png" alt="Monitor-Specific UI Rescaling Preference" width="600">
+        <img src="images/rescaling_setting-preference.png" alt="Monitor-Specific UI Rescaling Preference" width="600"/>
       </p>
       <p>
         The images below demonstrate the scaling behavior in an extract of an Eclipse application when moving the window
@@ -129,11 +129,11 @@ ul {padding-left: 13px;}
       </p>
       <p>
         With monitor-specific UI rescaling <b>disabled</b>:
-        <img src="images/rescaling_disabled.png" alt="Monitor-Specific UI Rescaling Disabled" width="600">
+        <img src="images/rescaling_disabled.png" alt="Monitor-Specific UI Rescaling Disabled" width="600"/>
       </p>
       <p>
         With monitor-specific UI rescaling <b>enabled</b>:
-        <img src="images/rescaling_enabled.png" alt="Monitor-Specific UI Rescaling Enabled" width="600">
+        <img src="images/rescaling_enabled.png" alt="Monitor-Specific UI Rescaling Enabled" width="600"/>
       </p>
     </td>
   </tr>
@@ -145,7 +145,7 @@ ul {padding-left: 13px;}
         maintenance. It is replaced with the WebView2 engine used by Edge. Switching to this modern engine will ensure that
         use cases keep working or enables uses cases that are not working with Internet Explorer anymore or have never been
         working with it. As an example, if an Eclipse application is executed in dark mode, according CSS styling of web
-        pages will be applied if embedded via:<br>
+        pages will be applied if embedded via:<br/>
         <code>@media (prefers-color-scheme: dark) { ... }</code>
       </p>
       <p>
@@ -159,20 +159,20 @@ ul {padding-left: 13px;}
       </p>
       <p>
         In case you want to or need to still use Internet Explorer in your Eclipse product, you can:
-        <ul>
-          <li>Switch to Internet Explorer for a complete product by setting the VM argument (for example in your
-            <i>eclipse.ini</i>: <code>-Dorg.eclipse.swt.browser.DefaultType=IE</code>
-          </li>
-          <li>Programmatically create a single browser instance with Internet Explorer by passing the flag
-            <code>SWT.IE</code> to the browser constructor
-          </li>
-          <li>
-            Create a fragment for host plug-in <code>org.eclipse.swt</code> containing a class with qualified name
-            <code>org.eclipse.swt.browser.BrowserInitializer</code> that sets the system property
-            <code>-Dorg.eclipse.swt.browser.DefaultType=IE</code> in its static initializer.
-          </li>
-        </ul>
       </p>
+      <ul>
+        <li>Switch to Internet Explorer for a complete product by setting the VM argument (for example in your
+          <i>eclipse.ini</i>: <code>-Dorg.eclipse.swt.browser.DefaultType=IE</code>
+        </li>
+        <li>Programmatically create a single browser instance with Internet Explorer by passing the flag
+          <code>SWT.IE</code> to the browser constructor
+        </li>
+        <li>
+          Create a fragment for host plug-in <code>org.eclipse.swt</code> containing a class with qualified name
+          <code>org.eclipse.swt.browser.BrowserInitializer</code> that sets the system property
+          <code>-Dorg.eclipse.swt.browser.DefaultType=IE</code> in its static initializer.
+        </li>
+      </ul>
     </td>
   </tr>
 


### PR DESCRIPTION
As indicated by the XML validation that actually all entries should conduct as described in:
https://github.com/eclipse-platform/www.eclipse.org-eclipse/blob/6f86e86fa407ceb70c05ff39726d248311d638fc/news/instructions.html#L40-L43