### PR TITLE
Eclipse plug-in migration guide (porting) 4.35

### DIFF
--- a/development/porting/eclipse_4_35_porting_guide.html
+++ b/development/porting/eclipse_4_35_porting_guide.html
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html lang="en">
+<head>
+<meta name="copyright" content="Copyright (c) IBM Corporation and others 2025. This page is made available under license. For full details see the LEGAL in the documentation book that contains this page." >
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<meta http-equiv="Content-Style-Type" content="text/css">
+<link rel="STYLESHEET" href="../book.css" charset="ISO-8859-1" type="text/css">
+<title>Eclipse 2025-03 (4.35) Plug-in Migration Guide</title>
+</head>
+
+<body>
+
+<h1>Eclipse 2025-03 (4.35) Plug-in Migration Guide</h1>
+<p>This guide covers migrating Eclipse 4.34 plug-ins to Eclipse 4.35.</p>
+<p>One of the goals of Eclipse 4.35 was to move Eclipse forward while remaining compatible 
+  with previous versions to the greatest extent possible. That is, plug-ins written 
+  against the Eclipse 4.34 APIs should continue to work in 4.35 in spite of any API changes.</p>
+<p>The key kinds of compatibility are API contract compatibility and binary compatibility. 
+  API contract compatibility means that valid use of 4.34 APIs remains valid for 
+  4.35, so there is no need to revisit working code. Binary compatibility means 
+  that the API method signatures, etc. did not change in ways that would cause 
+  existing compiled (&quot;binary&quot;) code to no longer link and run with the 
+  new 4.35 libraries.</p>
+<p>While every effort was made to avoid breakage, there are a few areas of incompatibility or new
+  APIs that should be adopted by clients. 
+  These documents describe those areas and provide instructions for migrating 4.34 plug-ins to 
+  4.35.</p>
+<ul>
+  <li><a href="https://help.eclipse.org/2025-03/topic/org.eclipse.platform.doc.isv/porting/eclipse_4_35_porting_guide.html?cp=2_3_1_0">
+        Eclipse Platform 2025-03 (4.35) Plug-in Migration Guide</a></li>
+  <li><a href="https://help.eclipse.org/2025-03/topic/org.eclipse.platform.doc.isv/porting/removals.html?cp=2_3_0">
+        Deprecated API removals in Eclipse Platform</a></li>
+  <li><a href="https://help.eclipse.org/2025-03/topic/org.eclipse.jdt.doc.isv/porting/eclipse_4_35_porting_guide.html?cp=3_2_0_0">
+        Eclipse JDT 2025-03 (4.35) Plug-in Migration Guide</a></li>
+</ul>
+
+</body>
+</html>


### PR DESCRIPTION
Eclipse plug-in migration guide (porting) 4.35