### PR TITLE
Fix  https://eclipse.dev/eclipse redirect to 404.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="refresh" content="0; url=https://projects.eclipse.org/projects/eclipse.platform">
+		<script type="text/javascript">
+			window.location.href = "https://projects.eclipse.org/projects/eclipse.platform"
+		</script>
+		<title>Eclipse Project Redirection</title>
+</head>
+
+<body>
+	If you are not redirected automatically,
+	follow this <a href='https://projects.eclipse.org/projects/eclipse.platform'>link</a>.
+</body>
+
+</html>


### PR DESCRIPTION
- It currently redirects to https://www.eclipse.org/errors/404.html but it would be better to redirect to portal, e.g.,
https://projects.eclipse.org/projects/eclipse.platform
- More correct would be https://projects.eclipse.org/projects/eclipse but it's quite bogus in content.

https://github.com/eclipse-equinox/equinox/pull/895