### PR TITLE
Fix image names and other minor (HTML) corrections in N&N for 4.36

### DIFF
--- a/news/4.36/jdt.html
+++ b/news/4.36/jdt.html
@@ -131,14 +131,14 @@
 					(see the news for <a href="../4.35/jdt.html#new-folding">4.35</a>).
 					The feature has been further improved since then and is now <b>enabled by default</b>.
 					<p>
-						This feature enhances the code folding mechanism in Eclipse JDT by enabling folding for control statements such as if, while, switch, and for. </b>
+						This feature enhances the code folding mechanism in Eclipse JDT by enabling folding for control statements such as <b>if</b>, <b>while</b>, <b>switch</b>, and <b>for</b>.
 						It improves code readability and navigation by allowing developers to collapse and expand structured blocks.
 					</p>
-					<img src="images/new_folding.png" alt="View of the new folding" />
+					<img src="images/new-folding.png" alt="View of the new folding" />
 					<p>
-						The feature can be disabled in the settings under <b>Java &gt; Editor &gt; Folding</b>.<br>
+						The feature can be disabled in the settings under <b>Java &gt; Editor &gt; Folding</b>.<br/>
 					</p>
-					<img src="images/settings_folding.png" alt="Settings view of the folding" />
+					<img src="images/settings-folding.png" alt="Settings view of the folding" />
 				</td>
 			</tr>
 			<!-- ******************* End of Java Editor ************************************* -->
@@ -177,20 +177,19 @@
 				<td class="title">Collapsing Stack Frames</td>
 				<td class="content">
 					Navigating in deep stack frames can be challenging during debuging, due to the high number of stack frames that are not relevant most of the time,
-					for example because they are provided by either the JDK, by a testing framework, or by a library</b>
+					for example because they are provided by either the JDK, by a testing framework, or by a library.
 					This feature tries to help focus on the stack frames that are coming from the user-created projects,
 					drastically reducing the unnecessary noise in the Debug View.
 					<p></p>
 					<img src="images/not-collapsed.png" alt="Original" />
 					<p>
-						The feature can be enabled from the Debug toolbar in <b>Debug &gt; Java &gt; Collapse Stack Frames</b>.<br>
+						The feature can be enabled from the Debug toolbar in <b>Debug &gt; Java &gt; Collapse Stack Frames</b>.<br/>
 					</p>
 					<img src="images/menuitem.png" alt="Menu to enable" />
 					<p>
 						After enabling it, the view becomes much simpler and less intimidating:
 					</p>
 					<img src="images/collapsed.png" alt="Collapsed stack frames" />
-				</td>
 				</td>
 			</tr>
 


### PR DESCRIPTION
Non-existing image files were being referenced in the code.

Also get rid of some other findings that were reported by the HTML validator in W3.org: https://validator.w3.org/check