### PR TITLE
Add support for new and noteworthy authored as markdown

### DIFF
--- a/markdown/index.html
+++ b/markdown/index.html
@@ -153,7 +153,14 @@
 		const targetElement = document.getElementById('markdown-target');
 
 		function niceName(name) {
-			return name.replaceAll(/[_-]/g, ' ').replaceAll(/([a-z])([A-Z])/g, '$1 $2').replace(/^([a-z])/, letter => letter.toLocaleUpperCase())
+			const result = name.replaceAll(/[_-]/g, ' ').replaceAll(/([a-z])([A-Z])/g, '$1 $2').replace(/^([a-z])/, letter => letter.toLocaleUpperCase())
+			if (result == 'Platform isv') {
+				return 'Platform ISV';
+			}
+			if (result == 'Api' || result == 'Pde' || result == 'Jdt') {
+				return result.toLocaleUpperCase();
+			}
+			return result;
 		}
 
 		function fixHash(hash) {
@@ -281,6 +288,24 @@
 			}
 		}
 
+		function generateNewsBreadcrumb(normalizedPath) {
+			if (selfHosted) {
+				const parts = /news\/(?<version>[^/]+)\/(?<filename>[^/]+).md/.exec(normalizedPath);
+				if (parts != null) {
+					const breadcrumb = document.querySelector(".breadcrumb");
+					const version = parts.groups.version;
+					const filename = parts.groups.filename;
+					const lastPart = filename == 'index' ? '' : `<li>${niceName(filename)}</li>`;
+					breadcrumb.append(...toElements(`
+<li><a href="${scriptBase}news/index.html">News</a></li>
+<li><a href="${scriptBase}markdown/index.html?file=eclipse-platform/www.eclipse.org-eclipse/master/news/${version}/index.md">${version}</a></li>
+${lastPart}
+`));
+					return true;
+				}
+			}
+			return false;
+		}
 
 		if (parts == null || parts.length == 0) {
 			targetElement.innerHTML = 'No well-formed query parameter of the form <code>?file=org/repo/branch/path</code> has been specified.';
@@ -290,15 +315,16 @@
 			} else {
 				document.title = `${repoName} Documentation | Eclipse Project`;
 
-				const breadcrumb = document.querySelector(".breadcrumb");
 				const normalizedPath = path.replace(/\/$/, '');
-				const segments = normalizedPath == '' ? [''] : ['', ...normalizedPath.split('/')];
-				let crumbPath = '';
-				for (const segment of segments) {
-					crumbPath = (crumbPath == '/' ? '/' : crumbPath + '/') + segment;
-					breadcrumb.append(...toElements(`<li><a href="?file=${org}/${repo}/${branch}${crumbPath}">${segment.length == 0 ? repoName : niceName(segment.replace(/\.md$/, ''))}</a></li>`));
+				if (!generateNewsBreadcrumb(normalizedPath)) {
+					const breadcrumb = document.querySelector(".breadcrumb");
+					const segments = normalizedPath == '' ? [''] : ['', ...normalizedPath.split('/')];
+					let crumbPath = '';
+					for (const segment of segments) {
+						crumbPath = (crumbPath == '/' ? '/' : crumbPath + '/') + segment;
+						breadcrumb.append(...toElements(`<li><a href="?file=${org}/${repo}/${branch}${crumbPath}">${segment.length == 0 ? repoName : niceName(segment.replace(/\.md$/, ''))}</a></li>`));
+					}
 				}
-
 
 				const logicalBaseURL = new URL(`https://api.github.com/repos/${org}/${repo}/contents/${path}`);
 				const apiURL = `${logicalBaseURL}?ref=${branch}`;

--- a/news/4.36/index.md
+++ b/news/4.36/index.md
@@ -1,0 +1,13 @@
+# Eclipse 4.36 - New and Noteworthy
+
+Welcome to the Eclipse SDK project!
+The Eclipse SDK project is part of the Eclipse 2025-06 simultaneous release.
+The Eclipse SDK and related resources can be downloaded from the [Eclipse Project downloads](https://download.eclipse.org/eclipse/downloads/) page.
+The Eclipse installer and other packages can be downloaded from the [IDE Downloads](https://www.eclipse.org/downloads/packages) page.
+
+Here are some of the more noteworthy items available in this release.
+
+- [New features in the Platform and Equinox](platform.md)
+- [New features for Java developers](jdt.md)
+- [New APIs in the Platform and Equinox](platform_isv.md)
+- [New features for plug-in developers](pde.md)

--- a/news/4.36/jdt.md
+++ b/news/4.36/jdt.md
@@ -1,0 +1,132 @@
+# Java Development Tools - 4.36
+
+<!--
+---
+## Java&trade; XX Support 
+-->
+
+<!--
+---
+## JUnit
+-->
+
+---
+## Java Editor
+
+### Custom Folding Regions
+
+It is now possible to create custom folding regions by specifying a comment at the start and end of the region.
+You can enable and configure this feature under `Window > Preferences > Java > Editor > Folding > Custom folding regions`.
+
+![Preference page for custom folding regions](images/custom_folding_regions_preferences.png)
+
+on that preference page, you can specify the text that should be used to start and end a custom folding region.
+When this is enabled,
+writing a comment starting with the specified region start followed by another comment starting with the specified region end creates a folding region.
+
+![code containing comments with the text 'region' and 'endregion'](images/custom_folding_regions_code_expanded.png)
+					
+Custom folding regions can be collapsed like any other folding regions.
+
+![custom folding regions are collapsed](images/custom_folding_regions_code_collapsed.png)
+					
+### Project Properties Page for Folding
+				
+Preferences for folding can now be configured on a per-project basis in addition to configuring folding for the workspace.
+This page is available under `Project > Properties > Java Editor > Folding`.
+
+![Project Properties page for folding](images/folding_property_page.png)
+			
+### New folding mechanism as Default
+
+In the previous release, a preference to enable different kinds of folding was introduced,
+see the news for [4.35](../4.35/jdt.html#new-folding).
+The feature has been further improved since then and is now **enabled by default**.
+
+This feature enhances the code folding mechanism in Eclipse JDT by enabling folding for control statements 
+such as **if**, **while**, **switch**, and **for**.
+It improves code readability and navigation by allowing developers to collapse and expand structured blocks.
+
+![View of the new folding](images/new-folding.png)
+
+The feature can be disabled in the settings under `Java > Editor > Folding`.
+
+
+![Settings view of the folding](images/settings-folding.png)
+
+<!--
+---
+## Java Views and Dialogs
+-->
+
+<!--
+---
+## Java Compiler
+-->
+
+<!--
+---
+## Java Formatter
+-->
+			
+---
+## Debug
+
+### Collapsing Stack Frames
+
+Navigating in deep stack frames can be challenging during debuging, due to the high number of stack frames that are not relevant most of the time,
+for example because they are provided by either the JDK, by a testing framework, or by a library.
+This feature tries to help focus on the stack frames that are coming from the user-created projects,
+drastically reducing the unnecessary noise in the Debug View.
+
+![Original](images/not-collapsed.png)
+
+The feature can be enabled from the Debug toolbar in `Debug > Java > Collapse Stack Frames`.
+
+![Menu to enable](images/menuitem.png)
+
+After enabling it, the view becomes much simpler and less intimidating:
+
+![Collapsed stack frames](images/collapsed.png)
+
+### Navigate to Variable Declaration
+
+Users can now navigate to a variable’s declaration directly from the Variables view during a debug session,
+making it easier to locate a variable, especially in methods with numerous local variables.
+
+Choose `Navigate to Declaration` from context menu of a variable.
+
+![Navigation_menu](images/NavigateToDeclareMenu.png)
+
+The editor will jump and highlight its declaration.
+
+![Navigation_done](images/Navigation.png)
+
+### Auto-Resuming Trigger Points
+
+Trigger points can now be configured to automatically resume execution when hit,
+allowing breakpoints after the trigger point to be activated while skipping those before it,
+thereby enabling a more focused and efficient debugging workflow.
+
+Upon enabling a trigger point, a new option will be shown to `Continue execution on hit` or not.
+
+![Triggerpoint Enabled](images/TriggerEnabled.png)
+
+Once `Continue execution on hit` is toggled, the breakpoint label will update to `[Resume on hit]` meaning it won't suspend on hit.
+
+![Triggerpoint Continue](images/TriggerContinue.png)
+
+Resume trigger also supports conditions, meaning if condition is true it will resume the execution otherwise it will suspend.
+
+![Resume-Triggerpoint with conditions](images/ResumeWithCondition.png)
+
+Now when you run in debug mode, the trigger point won't hit, allowing you to skip previous breakpoints, and stop on the actual breakpoint on which you need to focus.
+
+For example, here `Resume trigger` was set on line number 7 and during debugging it hit on line number 8 by skipping all the previous breakpoints.
+
+![Resume-Triggerpoint execution](images/TriggerExecution.png)
+
+<!--
+### JDT Developers
+-->
+					

--- a/news/4.36/pde.md
+++ b/news/4.36/pde.md
@@ -1,0 +1,14 @@
+# Plug-in Development Environment - 4.36
+
+<!--
+## Editors
+-->
+
+<!--
+## API Tools
+-->
+
+<!--
+---
+## PDE Compiler 
+-->

--- a/news/4.36/platform.md
+++ b/news/4.36/platform.md
@@ -1,0 +1,63 @@
+
+# Platform and Equinox - 4.36 
+
+<!--
+---
+## Views, Dialogs and Toolbar
+-->
+
+<!--
+---
+## Text Editors
+-->
+
+<!--
+---
+## Preferences
+-->
+
+<!--
+---
+## Themes and Styling
+-->
+
+<!--
+---
+## Views, Dialogs and Toolbar
+-->
+
+---
+## General Updates
+
+### Monitor-Specific UI Scaling as Default (Windows only)
+
+In the previous releases, a preference to enable an improved, monitor- and resolution-specific UI scaling on Windows was introduced,
+see the news for [4.34](../4.34/platform.html#rescale-on-runtime-preference)
+and [4.35](../4.35/platform.html#rescaleOnRuntimePreference) for details.
+The feature has been further improved since then and is now **enabled by default**.
+
+The feature makes each window adapt its scaling to the monitor it is currently placed on in a sharp, resolution-specific way
+and without requiring the application to restart.
+When using multiple windows, each of them will adapt its scaling to the monitor it is placed on.
+When enabled, this new feature replaces the current, limited scaling support for high-resolution monitors,
+which initializes the application's window according to the scaling of the primary monitor at application startup
+and produces blurry scaling when moving the window to another monitor unless the application is restarted.
+
+To disable this feature, uncheck the _Monitor-specific UI scaling_ box on the **Appearance** preference page
+(`Window > Preferences > General > Appearance`),
+as shown in the image below.
+The feature is still under further development. We encourage users to **share their feedback** to help us improve the functionality.
+
+![Monitor-Specific UI Rescaling Preference](images/rescaling_settings-preference.png)
+
+The images below demonstrate the scaling behavior in an extract of an Eclipse application when moving the window
+from a primary monitor with 100% scaling to another monitor with 200% scaling, first having the feature disabled
+and second having it enabled.
+
+On a 200% monitor with the feature being **disabled**:
+
+![Monitor-Specific UI Rescaling Disabled](images/rescaling-disabled.png)
+
+On a 200% monitor with the feature being **enabled**:
+
+![Monitor-Specific UI Rescaling Enabled](images/rescaling-enabled.png)

--- a/news/4.36/platform_isv.md
+++ b/news/4.36/platform_isv.md
@@ -1,0 +1,11 @@
+# Platform and Equinox API - 4.36
+
+<!--
+---
+## Platform Changes
+-->
+
+<!--
+---
+## SWT Changes
+-->


### PR DESCRIPTION
- Convert all the existing pages for 4.36 to *.md.
- The *.html pages will be deleted as a subsequent step.
- Specialize the breadcrumbs for these pages.