### PR TITLE
Simplify URLs to remove explicit use of index.html

### DIFF
--- a/eclipse-charter.html
+++ b/eclipse-charter.html
@@ -11,7 +11,7 @@
 <body>
 
 	<div data-generate="generateDefaultBreadcrumb(this)">
-		<a href="index.html">Eclipse</a>
+		<a href=".">Eclipse</a>
 		<span>Charter</span>
 	</div>
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 	</div>
 
 	<div data-generate="generateDefaultNav(this)">
-		<a class=" highlight fa-wpforms" href="development/index.html" title="More: Plans, Notes, Guides">
+		<a class=" highlight fa-wpforms" href="development/" title="More: Plans, Notes, Guides">
 			<div>More&mldr;<p>Plans, Notes, Guides&mldr;</p>
 			</div>
 		</a>
@@ -57,7 +57,7 @@
 			as a rich client platform (<a href="https://github.com/eclipse-platform/eclipse.platform.ui/blob/master/docs/Rich_Client_Platform.md">RCP</a>),
 			and as a comprehensive tool integration platform.
 			These services and frameworks include a standard workbench user interface model
-			and a portable native widget toolkit (<a href="swt/index.html">SWT</a>),
+			and a portable native widget toolkit (<a href="swt">SWT</a>),
 			a project model for managing resources,
 			automatic resource delta management for incremental compilers and builders,
 			language-independent debug infrastructure,

--- a/markdown/index.html
+++ b/markdown/index.html
@@ -96,7 +96,7 @@
 
 <body>
 	<div data-generate="generateDefaultBreadcrumb(this)">
-		<a href="../index.html">Eclipse</a>
+		<a href="../">Eclipse</a>
 	</div>
 
 	<div data-generate="generateDefaults(this)">
@@ -130,7 +130,7 @@
 		const selfHosted = repo == 'www.eclipse.org-eclipse';
 		const repoName = parts == null ? '' : repoNames[`${org}/${repo}`];
 
-		const localSiteNavigator = isLocalHost ? `<a href="${scriptBase}markdown/index.html?file=eclipse-platform/www.eclipse.org-eclipse/master/">Eclipse Website Navigator</a>` : '';
+		const localSiteNavigator = isLocalHost ? `<a href="${markdownBase}eclipse-platform/www.eclipse.org-eclipse/master/">Eclipse Website Navigator</a>` : '';
 		defaultAside = toElements(`${markdownAside}${localSiteNavigator}`);
 
 		if (parts != null && parts.groups.path.endsWith('.md')) {
@@ -297,8 +297,8 @@
 					const filename = parts.groups.filename;
 					const lastPart = filename == 'index' ? '' : `<li>${niceName(filename)}</li>`;
 					breadcrumb.append(...toElements(`
-<li><a href="${scriptBase}news/index.html">News</a></li>
-<li><a href="${scriptBase}markdown/index.html?file=eclipse-platform/www.eclipse.org-eclipse/master/news/${version}/index.md">${version}</a></li>
+<li><a href="${scriptBase}news/">News</a></li>
+<li><a href="${markdownBase}eclipse-platform/www.eclipse.org-eclipse/master/news/${version}/index.md">${version}</a></li>
 ${lastPart}
 `));
 					return true;

--- a/news/news.html
+++ b/news/news.html
@@ -24,7 +24,7 @@
 	</div>
 
 	<div data-generate="generateDefaultBreadcrumb(this)">
-		<a href="../index.html">Eclipse</a>
+		<a href="..">Eclipse</a>
 		<a href="news.html">News</a>
 	</div>
 

--- a/project.js
+++ b/project.js
@@ -7,9 +7,9 @@ window.onscroll = function() {
 
 const scriptBase = new URL(".", document.currentScript.src).href
 const apiGitHub = 'https://api.github.com/repos/eclipse-platform/www.eclipse.org-eclipse/contents/';
-const markdownBase = `${scriptBase}markdown/index.html?file=`;
-const selfHostedMarkdownBase = `${markdownBase}eclipse-platform/www.eclipse.org-eclipse/master/`;
+const markdownBase = `${scriptBase}markdown/?file=`;
 const newsBase = `${scriptBase}news/news.html?file=`;
+const selfHostedMarkdownBase = `${markdownBase}eclipse-platform/www.eclipse.org-eclipse/master/`;
 
 let meta = toElements(`
 <meta charset="utf-8">
@@ -46,7 +46,7 @@ let defaultNav = toElements(`
 	title="Support: Discussions">
 	Support<p>Discussions</p>
 </a>
-<a class="fa-newspaper-o" href="${scriptBase}news/news.html"
+<a class="fa-newspaper-o" href="${scriptBase}news/"
 	title="News: Noteworthy">
 	News<p>Noteworthy</p>
 </a>
@@ -57,7 +57,7 @@ let projectAside = `
 <a class="separator" href="https://projects.eclipse.org/projects/eclipse"><i class='fa fa-cube'></i> Eclipse Project</a>
 <a href="https://projects.eclipse.org/projects/eclipse.equinox">Equinox</a>
 <a href="https://projects.eclipse.org/projects/eclipse.platform">Platform</a>
-<a href="${scriptBase}swt/index.html">&nbsp;&nbsp;&bullet;&nbsp;SWT</a>
+<a href="${scriptBase}swt">&nbsp;&nbsp;&bullet;&nbsp;SWT</a>
 <a href="https://projects.eclipse.org/projects/eclipse.jdt">Java Development Tools</a>
 <a href="https://projects.eclipse.org/projects/eclipse.pde">Plug-in Development Environment</a>
 `;
@@ -72,11 +72,11 @@ let githubAside = `
 
 let markdownAside = `
 <span class="separator"><i class='fa fa-edit'></i> Markdown</span>
-<a href="${scriptBase}markdown/index.html?file=eclipse-platform/eclipse.platform/master/docs">Platform</a>
-<a href="${scriptBase}markdown/index.html?file=eclipse-platform/eclipse.platform.ui/master/docs">Platform UI</a>
-<a href="${scriptBase}markdown/index.html?file=eclipse-pde/eclipse.pde/master/docs">PDE</a>
-<a href="${scriptBase}markdown/index.html?file=eclipse-equinox/p2/master/docs">Equinox p2</a>
-<a href="${scriptBase}markdown/index.html?file=eclipse-ide/.github/main/">Eclipse IDE</a>
+<a href="${markdownBase}eclipse-platform/eclipse.platform/master/docs">Platform</a>
+<a href="${markdownBase}eclipse-platform/eclipse.platform.ui/master/docs">Platform UI</a>
+<a href="${markdownBase}eclipse-pde/eclipse.pde/master/docs">PDE</a>
+<a href="${markdownBase}eclipse-equinox/p2/master/docs">Equinox p2</a>
+<a href="${markdownBase}eclipse-ide/.github/main/">Eclipse IDE</a>
 `;
 
 let defaultAside = toElements(`
@@ -90,9 +90,9 @@ let tableOfContentsAside = '';
 let selfContent = document.documentElement.outerHTML;
 
 function redirect(href) {
-	const location = href != null ? href : new URL(`${scriptBase}markdown/index.html?file=eclipse-platform/www.eclipse.org-eclipse/master${window.location.pathname.replace(/^\/eclipse/, '').replace(/\.html$/, '.md')}`);
+	const location = href != null ? `${href}${window.location.search}${window.location.hash}`  : new URL(`${markdownBase}eclipse-platform/www.eclipse.org-eclipse/master${window.location.pathname.replace(/^\/eclipse/, '').replace(/\.html$/, '.md')}`);
 	const body = document.querySelector('body')
-	replaceChildren(body, "body", ...toElements(`<div>If you are not redirected automatically, 	follow this <a href='${location}'>link</a>.</div>`));
+	replaceChildren(body, "body", ...toElements(`<div style="display: none">If you are not redirected automatically, 	follow this <a href='${location}'>link</a>.</div>`));
 	window.location = location;
 }
 
@@ -377,7 +377,7 @@ function generateNav() {
 	return `
 <div class="header_nav">
 	<div class="col-xs-24 col-md-10 vcenter">
-		<a href="${scriptBase}index.html">
+		<a href="${scriptBase}">
 			<img src="${scriptBase}eclipse.svg" alt="The Main Index Page" xwidth="50%" xheight="auto" class="img-responsive header_nav_logo"/>
 		</a>
 	</div><!-- NO SPACES

--- a/templates/custom-content.html
+++ b/templates/custom-content.html
@@ -18,12 +18,13 @@
 	<div id="breadcrumb">
 		<a href="https://eclipseide.org/">Home</a>
 		<a href="https://eclipseide.org/projects/">Projects</a>
-		<a href="../index.html">Eclipse</a <a href="index.html">Templates</a>
+		<a href="..">Eclipse</a>
+		<a href=".">Templates</a>
 		<span class="highlight">Custom</spanclass="highlight">
 	</div>
 
 	<div id="aside">
-		<a href="index.html" class="separator"><i class='fa fa-pencil'></i> Templates</a>
+		<a href="." class="separator"><i class='fa fa-pencil'></i> Templates</a>
 		<a href="extended-content.html">Extended Scaffolding</a>
 		<a href="custom-content.html">Custom Scaffolding</a>
 		<a href="icons.html">Navigation Icons</a>

--- a/templates/extended-content.html
+++ b/templates/extended-content.html
@@ -21,13 +21,13 @@
 	</div>
 
 	<div data-generate="generateDefaultBreadcrumb(this)">
-		<a href="../index.html">Eclipse</a>
-		<a href="index.html">Templates</a>
+		<a href="..">Eclipse</a>
+		<a href=".">Templates</a>
 		<span class="highlight">Extended</span">
 	</div>
 
 	<div data-generate="generateDefaultAside(this)">
-		<a href="index.html" class="separator"><i class='fa fa-pencil'></i> Templates</a>
+		<a href="." class="separator"><i class='fa fa-pencil'></i> Templates</a>
 		<a href="extended-content.html">Extended Scaffolding</a>
 		<a href="custom-content.html">Custom Scaffolding</a>
 		<a href="icons.html">Navigation Icons</a>

--- a/templates/icons.html
+++ b/templates/icons.html
@@ -11,8 +11,8 @@
 <body>
 
 	<div data-generate="generateDefaultBreadcrumb(this)">
-		<a href="../index.html">Eclipse</a>
-		<a href="index.html">Templates</a>
+		<a href="..">Eclipse</a>
+		<a href=".">Templates</a>
 	</div>
 
 	<div data-generate="generateDefaultHeader(this)">

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,12 +11,12 @@
 <body>
 
 	<div data-generate="generateDefaultBreadcrumb(this)">
-		<a href="../index.html">Eclipse</a>
+		<a href="..">Eclipse</a>
 		<span>Templates</span>
 	</div>
 
 	<div data-generate="generateDefaultAside(this)">
-		<a href="index.html" class="separator"><i class='fa fa-pencil'></i> Templates</a>
+		<a href="." class="separator"><i class='fa fa-pencil'></i> Templates</a>
 		<a href="extended-content.html">Extended Scaffolding</a>
 		<a href="custom-content.html">Custom Scaffolding</a>
 		<a href="icons.html">Navigation Icons</a>


### PR DESCRIPTION
- Oomph's http server has been augmented to transparently serve the index.html when it exists.
- This removal is especially helpful to shorten markdown URIs.