### PR TITLE
Improve styling of `<details><summary>`

### DIFF
--- a/markdown/index.html
+++ b/markdown/index.html
@@ -95,6 +95,30 @@
 			overflow-y: auto;
 		}
 
+		details>summary {
+			margin-bottom: 0.5em;
+		}
+
+		details>summary::before {
+			content: '▷️ ';
+			color: orange;
+		}
+
+		details[open]>summary::before {
+			content: '◢ ';
+			color: orange;
+		}
+
+		:target {
+			border-style: solid;
+			border-width: 1px;
+		}
+
+		#edit-markdown-link {
+			display: block;
+			margin-bottom: 1em;
+		}
+
 		/*]]>*/
 	</style>
 </head>
@@ -123,6 +147,9 @@
 			"eclipse-equinox/p2": "Equinox p2",
 			"eclipse-ide/.github": "Eclipse IDE",
 			"eclipse-simrel/.github": "Eclipse SimRel",
+			"eclipse-packaging/packages": "Eclipse Packaging Project",
+			"eclipse-orbit/.github": "Eclipse Orbit",
+			"eclipse-cbi/epl-license-feature": "EPL License Feature",
 		};
 
 		function getFileParameter() {
@@ -249,10 +276,10 @@
 
 				const headings = markedGfmHeadingId.getHeadingList();
 				const headingText = `
-			<ul id="table-of-contents">
-			${headings.map(({id, raw, level}) => `<li class="tl${level}"><a href="#${id}">${raw}</a></li>`).join(' ')}
-			</ul>
-			`;
+<ul id="table-of-contents">
+${headings.map(({id, raw, level}) => `<li class="tl${level}"><a href="#${id}">${raw}</a></li>`).join(' ')}
+</ul>
+`;
 				document.getElementById('toc-target').replaceChildren(...toElements(headingText));
 
 				const imgs = targetElement.querySelectorAll("img[src]");
@@ -314,6 +341,11 @@
 				}
 
 				document.getElementById('edit-markdown-link').href = `https://github.com/${org}/${repo}/blob/${branch}/${path}`;
+
+				// Ensure that we nagivate to the target.
+				if (document.location.hash.includes('#')) {
+					document.location.hash = document.location.hash;
+				}
 			}
 		}
 
@@ -340,13 +372,13 @@ ${lastPart}
 			targetElement.innerHTML = 'No well-formed query parameter of the form <code>?file=org/repo/branch/path</code> has been specified.';
 		} else {
 			if (repoName == null) {
-				const url = `https://github.com/${org}/${repo}/${branch}/${path}`;
+				const url = `https://github.com/${org}/${repo}/blob/${branch}/${path}`;
 				targetElement.innerHTML = `
 <div>
 The repository ${org}/${repo} is not on the allowed list.
 </div>
 <ul>
-<li><a href="{$url}${window.location.hash}">${url}</a></li>
+<li><a href="${url}${window.location.hash}">${url}</a></li>
 </ul>
 `;
 			} else {
@@ -372,7 +404,7 @@ The repository ${org}/${repo} is not on the allowed list.
 					fetch(url).then(response => {
 						return response.text();
 					}).then(text => {
-						if (text.startsWith('<')) {
+						if (text.startsWith('<') && !url.toString().endsWith('.md')) {
 							if (text.startsWith('<img') || text.match(/<ul><li><a href="[^"]+"> Parent Directory<\/a><\/li>/)) {
 								const links = [...text.matchAll(/href="([^./][^"]+?(\.md|\/))"/g).map(match => {
 									return {url: `https://api.github.com/repos/${org}/${repo}/contents/${path}/${match[1]}?ref=${branch}`};

--- a/project.js
+++ b/project.js
@@ -77,6 +77,7 @@ let markdownAside = `
 <a href="${markdownBase}eclipse-pde/eclipse.pde/master/docs">PDE</a>
 <a href="${markdownBase}eclipse-equinox/p2/master/docs">Equinox p2</a>
 <a href="${markdownBase}eclipse-ide/.github/main/">Eclipse IDE</a>
+<a href="${markdownBase}eclipse-simrel/.github/profile/README.md">Eclipse SimRel</a>
 `;
 
 let defaultAside = toElements(`


### PR DESCRIPTION
- Add epp and epl-license-feature to the approved list.
- Ensure that the hash target is selected and visible.
- Fix link to the blob URL of a non-approved github repo.
- Handle a *.md file that starts with <.
- Add a link to simrel in the markdown nav.