### PR TITLE
The sort method should return an int not a boolean

### DIFF
--- a/project.js
+++ b/project.js
@@ -722,7 +722,7 @@ function getFileList(location, pattern, handler, errorHandler) {
 		}
 
 		const entries = [...map].sort((a, b) => {
-			return a[0] < b[0]
+			return b[0] - a[0]
 		}).map(entry => entry[1]);
 
 		handler(entries);


### PR DESCRIPTION
- This affects the sorting of news version which are intended to be sorted numerically rather than lexicographically.