### PR TITLE
Define HttpServer launch configuration in this repo

### DIFF
--- a/Eclipse-website-local-server.launch
+++ b/Eclipse-website-local-server.launch
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
+    <setAttribute key="additional_plugins"/>
+    <booleanAttribute key="append.args" value="true"/>
+    <stringAttribute key="application" value="org.eclipse.oomph.util.HTTPServer"/>
+    <booleanAttribute key="askclear" value="true"/>
+    <booleanAttribute key="automaticAdd" value="false"/>
+    <booleanAttribute key="automaticIncludeRequirements" value="true"/>
+    <booleanAttribute key="automaticValidate" value="true"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <stringAttribute key="checked" value="[NONE]"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="false"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/Eclipse-website-local-server"/>
+    <booleanAttribute key="default" value="false"/>
+    <setAttribute key="deselected_workspace_bundles"/>
+    <stringAttribute key="featureDefaultLocation" value="workspace"/>
+    <stringAttribute key="featurePluginResolution" value="workspace"/>
+    <booleanAttribute key="includeOptional" value="false"/>
+    <stringAttribute key="location" value="@none"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog&#13;&#10;&#13;&#10;-alias /eclipse-&gt;${project_loc:/eclipse}"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#13;&#10;-Duser.home=${system_property:user.home}"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.eclipse.e4.demo.cssbridge.product"/>
+    <setAttribute key="selected_target_bundles">
+        <setEntry value="org.eclipse.oomph.util@default:default"/>
+    </setAttribute>
+    <setAttribute key="selected_workspace_bundles"/>
+    <booleanAttribute key="show_selected_only" value="false"/>
+    <stringAttribute key="templateConfig" value="${target_home}\configuration\config.ini"/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="true"/>
+    <booleanAttribute key="useProduct" value="false"/>
+</launchConfiguration>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ provide a pull request review to add it.
 Instructions for contributing a New & Noteworthy entry
 ------------------------------------------------------
 
-See [these instructions](https://eclipse.dev/eclipse/news/instructions.html) ([raw](news/instructions.html))
+See [these instructions](https://eclipse.dev/eclipse/news/instructions.html) ([raw](news/instructions.md))
 
 For more Information:
 ---------------------

--- a/news/instructions.md
+++ b/news/instructions.md
@@ -10,17 +10,13 @@ As of 4.36, New and Noteworthy is authored in markdown.
 
 #### Markdown Preview
 
-The standard
-[Oomph Setup](https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md#creating-an-eclipse-development-environment)
-for the website Github repository
-provides a launch configuration
-```Run > Run Configurations > Eclipse Applications > HTTPServer```
+A launch configuration is provided, named
+`Run > Run Configurations > Eclipse Applications > Eclipse-website-local-server`
 that you can run in order to serve the content of the Eclipse website project's contents via `localhost`.
 It will open a page in your default browser where the first link is to the root of the Eclipse website.
 This allows you to preview all the changes that you make to the website locally **before** you commit them.
 Sometimes it's necessary to do a deep refresh,
 e.g., `Ctrl-F5`.
-
 
 #### Pages
 
@@ -33,7 +29,7 @@ The `index.md` page describes the release and contains links to the component ne
 Add a new entry to the appropriate section in the corresponding markdown document.
 General standard sections are initially commented out in the markdown template.
 When adding an entry to a commented out section,
-remove the comment markers `<-- -->` arounding the section.
+remove the comment markers `<-- -->` surrounding the section.
 
 If required,
 you can add a new section to the document to highlight a feature,


### PR DESCRIPTION
Currently it's defined in the platform's Oomph setup at:
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/blob/d45efea79650f5d97369d8dacd2b19ff3e9a4f27/oomph/Platform.setup#L1029-L1078
, but defining it here simplifies updates (as changes are available as soon as one updates the git head) are and defines the launch-config where it's used from.
This also makes the name of the launch config a bit more specific.

@merks what do you think?
If this is submitted, I suggest to remove the resource-creation task linked above in the setup.

