### PR TITLE
Add other aliases to Eclipse-website-local-server launch config

### DIFF
--- a/Eclipse-website-local-server.launch
+++ b/Eclipse-website-local-server.launch
@@ -24,7 +24,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog&#13;&#10;&#13;&#10;-alias /eclipse-&gt;${project_loc:/eclipse}"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog&#13;&#10;&#13;&#10;-alias &#13;&#10;/eclipse-&gt;${project_loc:/eclipse}&#13;&#10;/eclipse-platform/eclipse.platform/master-&gt;${project_loc:/eclipse}/../eclipse.platform&#13;&#10;/eclipse-platform/eclipse.platform.ui/master-&gt;${project_loc:/eclipse}/../eclipse.platform.ui&#13;&#10;/eclipse-pde/eclipse.pde/master-&gt;${project_loc:/eclipse}/../eclipse.pde&#13;&#10;/eclipse-equinox/p2/master-&gt;${project_loc:/eclipse}/../p2"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#13;&#10;-Duser.home=${system_property:user.home}"/>
     <stringAttribute key="pde.version" value="3.3"/>


### PR DESCRIPTION
Also add the other aliases for the projects that contain markdown documentation as well.

Follow-up on
- https://github.com/eclipse-platform/www.eclipse.org-eclipse/pull/348