### PR TITLE
fix wrong bracket in terminal console support N&N

### DIFF
--- a/news/4.37/platform.md
+++ b/news/4.37/platform.md
@@ -41,7 +41,7 @@ well as these applications require a so called [pseudo terminal](https://en.wiki
 together with a [terminal emulator](https://en.wikipedia.org/wiki/Terminal_emulator) to behave as if it was
 executed on native command prompt.
 
-While the [VT100 terminal emulator}(https://en.wikipedia.org/wiki/VT100) was already added the in the last release,
+While the [VT100 terminal emulator](https://en.wikipedia.org/wiki/VT100) was already added the in the last release,
 there was still the need to start the application in a terminal session what is now available when launching a run from
 inside Eclipse as well!
 


### PR DESCRIPTION
This PR fixes a markdown link using `}` instead of `]` from #368.

![image](https://github.com/user-attachments/assets/0a721b73-9fd8-4913-88e5-279b4a6fcc30)
