### PR TITLE
Add newline to platform_isv.md for 4.37

### DIFF
--- a/news/4.37/platform_isv.md
+++ b/news/4.37/platform_isv.md
@@ -12,6 +12,7 @@ The previously provided Terminal View and the Local, SHH and Telnet Connectors f
 It has been part of the Eclipse EPPs for along time already and proven an useful extension to Eclipse IDE!
 
 To use it in your own product, or install it in a custom Eclipse IDE setup you can from now on use the feature `org.eclipse.terminal.feature`.
+
 <!--
 ---
 ## SWT Changes


### PR DESCRIPTION
The visualization looks odd in Firefox, maybe a line break is missing?

URL: https://eclipse.dev/eclipse/markdown/?f=news/4.37/platform_isv.md

<img width="1201" height="930" alt="image" src="https://github.com/user-attachments/assets/a229c52d-871e-417a-8550-6e71ca3a164e" />
