### PR TITLE
N&N for clarified ImageDataProvider contract and debugging support

### DIFF
--- a/news/4.37/platform_isv.md
+++ b/news/4.37/platform_isv.md
@@ -36,9 +36,14 @@ Display.getDefault().asyncExec(() -> {
 });
 ```
 
-<!--
----
+
 ## SWT Changes
--->
 
+### Clarified ImageDataProvider Contract
 
+The `ImageDataProvider` API documentation has been updated to clarify that implementations are expected to return **linearly scaled** `ImageData` based on the zoom level.
+For example, if `getImageData(100)` returns an image of width `w` and height `h`, then `getImageData(200)` must return an image of width `2 * w` and height `2 * h`, if non-null.
+This only makes an implicit assumption explicit, some consumers have always relied on this linear scaling behavior, and lack of it may have led to unexpected behavior in the past.
+
+Additionally, optional runtime checks verifying this linear scaling behavior are available as a debugging feature to assist developers in validating their implementations.  
+These checks can be enabled by starting the application with `-Dorg.eclipse.swt.internal.enableStrictChecks`, but note that this system property may be subject to change in future releases without prior notice.


### PR DESCRIPTION

The adds Add release news informing about the clarification of the contract as mentioned in  https://github.com/vi-eclipse/Eclipse-Platform/issues/377

This PR is to be merged after https://github.com/eclipse-platform/eclipse.platform.swt/pull/2391 
