### PR TITLE
Minor changes to improve the style and consistency of the documentation

### DIFF
--- a/news/4.37/jdt.md
+++ b/news/4.37/jdt.md
@@ -28,7 +28,8 @@ If the start and end region markers are the same, the same comment can be used t
 The last section automatically ends when the last block is closed or at the end of the file.
 
 This is useful if a class (or other Java file) contains multiple sections that are seperated with some comment.
-To use this functionality, check "Enable folding of custom regions" in `Window > Preferences > Java > Editor > Folding` and enter the same text in "Region start comment text" and "Region end comment text".
+To use this functionality, check `Enable folding of custom regions` in `Window → Preferences → Java → Editor → Folding`
+and enter the same text in `Region start comment text` and `Region end comment text`.
 
 ![Preference window with folding of custom regions enabled and the start and end region markers set to the same text](images/overlappingStartEndCustomRegionMarkersPrefs.png)
 
@@ -38,7 +39,7 @@ This marker can then be used in comments to separate start and end regions.
 
 ![The same Java class with some regions collapsed](images/overlappingStartEndCustomRegionMarkersCollapsed.png)
 
-### New quick-fix/clean-up to replace deprecated fields
+### New Quick-fix/Clean-up to Replace Deprecated Fields
 <details>
 <summary>Contributors</summary>
 
@@ -47,7 +48,7 @@ This marker can then be used in comments to separate start and end regions.
 
 In a previous release, support was added to replace deprecated method calls with a suggested replacement found in Javadoc.  With this release, it is now possible to also replace fields with suggested replacements.
 
-The new clean-up is found by going to the `Source Fixing` tab of the Clean-up Configuration dialog and selecting: `Replace deprecated field where possible`.  The quick-fix is accessible by clicking CTRL+space on the deprecated field reference.
+The new clean-up is found by going to the `Source Fixing` tab of the `Custom Clean Ups` dialog and selecting: `Replace deprecated field where possible`.  The quick-fix is accessible by clicking CTRL+space on the deprecated field reference.
 
 ![Setting the deprecated field clean-up](images/deprecatedFieldCleanUp.png)
 
@@ -61,7 +62,7 @@ results in:
 
 after applying the clean-up.
 
-### Access modifier specification added to Extract Method
+### Access Modifier Specification Added to Extract Method
 <details>
 <summary>Contributors</summary>
 
@@ -82,7 +83,8 @@ When extracting code to a method, a user can now specify access modifiers for th
 - [Suby S Surendran](https://github.com/subyssurendran666)
 </details>
 
-The ruler context menu in the editor has been enhanced to make debugging setup more efficient. You can now directly toggle a breakpoint with hit count or a triggerpoint by `right-clicking on the vertical ruler` (left margin), where the context menu includes the options Toggle Breakpoint with Hit Count and Toggle Triggerpoint.
+The ruler context menu in the editor has been enhanced to make debugging setup more efficient. You can now directly toggle a breakpoint with hit count or a triggerpoint
+by right-clicking on the vertical ruler (in left margin), where the context menu includes the options `Toggle Breakpoint with Hit Count` and `Toggle Triggerpoint`.
 
 ![Ruler context menu in the Java editor showing new entries for Toggle Breakpoint with Hit Count and Toggle Triggerpoint](images/rulerToggleMenuWithHitcountAndTriggerpoint.png)
 

--- a/news/4.37/pde.md
+++ b/news/4.37/pde.md
@@ -12,21 +12,21 @@ A special thanks to everyone who [contributed to PDE](acknowledgements.md#plug-i
 - [Christoph Läubrich ](https://github.com/laeubi)
 </details>
 
-PDE previously has created JUnit Plugin-test launches with some broad inclusion settings and defaults that do not always fit different project setups.
-From now on, it uses a more minimal approach when creating new JUnit Plugin-test launches by default that is only selecting the test-plugin and leverage
-the option to include all required dependencies automatically.
+PDE previously has created JUnit Plugin-test launches with some broad inclusion settings and defaults that do not always fit different project setups well.
+Now it uses a more minimal approach when creating new JUnit Plugin-test launches that only selects the test-plugin
+and leverages the option to include all required dependencies automatically.
 
-This results in much smaller launches that start up faster and do not pull in everything in your workspace by default what is especially a problem when
-many independent components in a workspace are to be tested.
+This results in much smaller launches that start up faster and do not pull in everything in your workspace by default
+which is especially a problematic when many independent components in a workspace are to be tested.
 
-Beside of this it is now possible to configure the used default settings for new launches to adapt to individual needs, because of this 
-we **strongly recommend** you review these settings and make sure they fit your needs after an upgrade.
+In addition, it is now possible to configure the default settings for new launches to adapt to individual needs.
+As a result, we **highly recommend** you review these settings to ensure they fit your needs after upgrading.
 
 ![New PDE Launch Settings](images/pde_junit_launch_config.png)
 
-As this only affects new launches, you either need to adapt existing launches or delete older ones so they are created with fresh settings on the next run,
-if you find any issues or difficulties using this feature don't hesitate to let us know and open an [issue](https://github.com/eclipse-pde/eclipse.pde/issues)
-or a new [discussion](https://github.com/eclipse-pde/eclipse.pde/discussions).
+As this only affects new launches, you either need to adapt existing launches or delete older ones so they are created with fresh settings on the next run.
+If you encounter any issues or difficulties using this feature don't hesitate to let us know by opening an [issue](https://github.com/eclipse-pde/eclipse.pde/issues)
+or starting a [discussion](https://github.com/eclipse-pde/eclipse.pde/discussions).
 
 ### OSGi Test Framework Support
 
@@ -37,17 +37,22 @@ or a new [discussion](https://github.com/eclipse-pde/eclipse.pde/discussions).
 </details>
 
 The [OSGi Testing Support](https://github.com/eclipse-osgi-technology/osgi-test#osgi-testing-support) is a great library for testing OSGi applications,
-and PDE now add first-class support as it does for OSGi Annotations already.
+and PDE now adds first-class support as it already did for OSGi Annotations.
 
-To enable this do the following:
+Enable this as follows:
 
-1. Make sure your target platform contains the necessary OSGi test dependencies, to make this more easy PDE provides a feature named `org.eclipse.pde.osgitest.dependencies.feature`.
-2. Go to the [Build Path Settings](https://help.eclipse.org/latest/topic/org.eclipse.jdt.doc.user/reference/ref-properties-build-path.htm) and add the JUNIT Library under the [Libraries Tab](https://help.eclipse.org/latest/topic/org.eclipse.jdt.doc.user/reference/ref-properties-build-path.htm#libraries) but do not add any JUnit or OSGi Testing imports/requirements to your manifest!
+1. Make sure your target platform contains the necessary OSGi test dependencies.
+   To make this easier, PDE provides a feature named `org.eclipse.pde.osgitest.dependencies.feature`.
+2. Go to the [Build Path Settings](https://help.eclipse.org/latest/topic/org.eclipse.jdt.doc.user/reference/ref-properties-build-path.htm)
+   and add the Junit Library under the [Libraries Tab](https://help.eclipse.org/latest/topic/org.eclipse.jdt.doc.user/reference/ref-properties-build-path.htm#libraries)
+   but do not add any JUnit or OSGi Testing imports/requirements to your manifest!
 3. Place your Tests into a source folder marked as test source
 
-PDE will then automatically add required dependencies for OSGi Testing Support and you can use all the standard annotations right now.
+PDE will then automatically add required dependencies for OSGi Testing Support and you can use all the standard annotations.
 
-After that just run your tests as the usual plugin test, you can find an example [here](examples/osgitest-example.zip), if you find any issues or has suggestions don't hesitate to let us know and open an issue [here](https://github.com/eclipse-pde/eclipse.pde/issues).
+After that just run your tests as the usual plugin test.
+You can find an example [here](examples/osgitest-example.zip).
+If you encounter issues or have suggestions don't hesitate to let us know by opening an [issue](https://github.com/eclipse-pde/eclipse.pde/issues).
 
 <!--
 ## Editors

--- a/news/4.37/platform.md
+++ b/news/4.37/platform.md
@@ -58,7 +58,7 @@ if something is missing or not working as expected.
 The terminal support can be installed as follows:
 
 - Download the latest integration build SDK [here](https://download.eclipse.org/eclipse/downloads/).
-- Go to `Help > Install New Software` and add the site https://download.eclipse.org/eclipse/updates/4.37-I-builds/ then select
+- Go to `Help → Install New Software` and add the site https://download.eclipse.org/eclipse/updates/4.37-I-builds/ then select
   `Terminal Feature` and `Terminal Session Support`.
 - Now in the toolbar choose the `Open a Terminal` icon ensure the `Terminal` view works for your platform.
 
@@ -88,10 +88,10 @@ The hotkey to open the search dialog is `Ctrl+F`,
 the dialog opens at the bottom left of the client area of the Browser widget. See screenshots below.
 
 The search dialog is closed with `Esc`.
-Its also closed when resizing or moving the `Browser` widget or its parent `Shell`.
+It's also closed when resizing or moving the `Browser` widget or its parent `Shell`.
 The dialog can be dragged and will remember its position until such a resize or move.
 
-The search can be disabled globally with the following VM property, e.g. in case of WebKit crashes:
+The search can be disabled globally with the following VM property, e.g., in case of WebKit crashes:
 
 ```
 -Dorg.eclipse.swt.internal.webkitgtk.disableBrowserSearch=true
@@ -167,15 +167,15 @@ This is how it looks with different values of that property:
 - [Sougandh S ](https://github.com/SougandhS)
 </details>
 
-To make breakpoint management easier, the `Breakpoints view` now organizes breakpoints into separate groups based on their enablement status. 
+To make breakpoint management easier, the `Breakpoints` view now organizes breakpoints into separate groups based on their enablement status. 
 This clearly distinguishes between breakpoints that are `enabled` and those that are `disabled`.
 
-To use this, go to more options of `Breakpoints view` then `Group By -> Enablement`
+To use this, go to more options of `Breakpoints` view then `Group By → Enablement`
 
 ![Breakpoint Grouping Menu](images/BreakpointGroupMenu.png)
 
-When this option is selected, enabled breakpoints are listed together at the top under an `Enabled group`.
-Disabled breakpoints appear below under `Disabled group`. This organization helps you quickly locate breakpoints that are enabled or disabled. 
+When this option is selected, enabled breakpoints are listed together at the top under an `Enabled` group.
+Disabled breakpoints appear below under `Disabled` group. This organization helps you quickly locate breakpoints that are enabled or disabled. 
 It makes it easier to re-enable or disable breakpoints without scrolling through a long list.
 
 ![Breakpoint Enablement Grouping](images/EnablementGrouping.png)

--- a/news/4.37/platform_isv.md
+++ b/news/4.37/platform_isv.md
@@ -23,7 +23,7 @@ See [Support Launching with a Terminal Console](platform.md#support-launching-wi
 </details>
 
 It is now possible to dynamically hide the context menu in the perspective switcher using the application model API. 
-This enables Eclipse RCP apps using 3.x API to enable and disable the menu at runtime.
+This allows Eclipse RCP apps using 3.x API to enable and disable the menu at runtime.
 
 Example usage:
 ```java
@@ -45,5 +45,6 @@ The `ImageDataProvider` API documentation has been updated to clarify that imple
 For example, if `getImageData(100)` returns an image of width `w` and height `h`, then `getImageData(200)` must return an image of width `2 * w` and height `2 * h`, if non-null.
 This only makes an implicit assumption explicit, some consumers have always relied on this linear scaling behavior, and lack of it may have led to unexpected behavior in the past.
 
-Additionally, optional runtime checks verifying this linear scaling behavior are available as a debugging feature to assist developers in validating their implementations.  
+Additionally, optional runtime checks verifying this linear scaling behavior are available as a debugging feature to assist developers in validating their implementations.
+
 These checks can be enabled by starting the application with `-Dorg.eclipse.swt.internal.enableStrictChecks`, but note that this system property may be subject to change in future releases without prior notice.


### PR DESCRIPTION
- Ensure all headings are title case.
- Use the same style for all menu paths.
- Break some very long lines.