### PR TITLE
Update N&N on new API for drawing scaled images

### DIFF
--- a/news/4.38/platform_isv.md
+++ b/news/4.38/platform_isv.md
@@ -9,19 +9,22 @@ A special thanks to everyone who [contributed to Eclipse-Platform](acknowledgeme
 
 ## SWT Changes
 
-### New API: `GC#drawImage(Image image, int destX, int destY, int destWidth, int destHeight)`
+### New GC API for Drawing Scaled Images
 
 <details>
-    <summary>Contributors</summary>
-    
-    - [Arun Jose](https://github.com/arunjose696)
+<summary>Contributors</summary>
+
+- [Arun Jose ](https://github.com/arunjose696)
+- [Heiko Klare ](https://github.com/HeikoKlare)
+- [Michael Bangas ](https://github.com/Michael5601)
 </details>
 
 #### Description
-A new `drawImage` method in `GC` allows drawing the **full image** into a specified destination rectangle.  
-Until now, the existing method  
-`drawImage(image, srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight)`  
-was used for this purpose by specifying the full source bounds. The new method simplifies the process by eliminating the need to provide the actual image bounds when drawing the entire image.
+A new `drawImage` method in `GC` allows drawing the **full image** into a specified destination rectangle:
+```java
+GC#drawImage(image, destX, destY, destWidth, destHeight)
+```  
+Until now, the existing method `drawImage(image, srcX, srcY, srcWidth, srcHeight, destX, destY, destWidth, destHeight)`  was used for this purpose by specifying the full source bounds. The new method simplifies the process by eliminating the need to provide the actual image bounds when drawing the entire image.
 
 #### New vs. Existing Method
 - **Existing method:** Handles scaling and cropping; requires explicit source bounds. Best suited for drawing a cropped part of the image. However, this is not a very common use case in Eclipse products, as images are mostly drawn at their full sizes.  
@@ -37,7 +40,7 @@ gc.drawImage(image, 0, 0, 200, 100);
 ```
 
 #### Additional Note
-When using the new `drawImage` method, images that can provide size-specific data (such as SVGs or images backed by `ImageDataAtSizeProvider`) are loaded at the destination size, avoiding blurry scaling.  
+When using the new `drawImage` method, images that can provide size-specific data (such as SVGs) are loaded at the destination size, avoiding blurry scaling.  
 For all other images the behavior remains the same as before _i.e._ they are loaded at the closest available zoom level.  
 This destination-size loading is currently only available in the new method but may be added to the existing method in the future.
 


### PR DESCRIPTION
- Fixes wrongly formatted contributors
- Adds missing contributors
- Improves title
- Improves formatting
- Removes statement on not-yet-released API

### Before
<img width="867" height="298" alt="image" src="https://github.com/user-attachments/assets/604c5ea5-730d-4684-af1b-bef35aaba877" />

### After
<img width="874" height="277" alt="image" src="https://github.com/user-attachments/assets/b4b99e35-306c-4361-b32d-2936349602df" />
