### PR TITLE
Improve N&N dirty indicator entry per review feedback

### DIFF
--- a/news/4.40/platform_isv.md
+++ b/news/4.40/platform_isv.md
@@ -18,11 +18,15 @@ A special thanks to everyone who [contributed to Eclipse-Platform](acknowledgeme
 - [Lars Vogel](https://github.com/vogella)
 </details>
 
-`CTabFolder` now supports an opt-in dirty indicator that shows a filled bullet dot (●) at the close button location for tabs with unsaved changes, replacing the traditional `*` prefix approach. On hover, the bullet transforms into the close button, matching VS Code behavior.
+`CTabFolder` now supports an opt-in dirty indicator that shows a filled bullet dot (●) at the close button location for tabs with unsaved changes.
+This is intended as an alternative to the `*` prefix dirty indicator currently used by the IDE.
+On hover, the bullet transforms into the close button, matching VS Code behavior.
 
 New API:
 - `CTabFolder.setDirtyIndicatorStyle(boolean)` — enables/disables the bullet-on-close-button style
+- `CTabFolder.getDirtyIndicatorStyle()` — returns whether the dirty indicator style is enabled
 - `CTabItem.setShowDirty(boolean)` — marks an item as having unsaved changes
+- `CTabItem.getShowDirty()` — returns whether the item is marked as dirty
 
 The feature is disabled by default to preserve backward compatibility.
 


### PR DESCRIPTION
## Summary
- Split long description into one sentence per line (per `news/instructions.md` convention)
- Add missing getter methods (`getDirtyIndicatorStyle()`, `getShowDirty()`) to the API listing

Addresses review comments from @merks on #531.

## Test plan
- [ ] Verify rendered markdown looks correct on the N&N page

🤖 Generated with [Claude Code](https://claude.com/claude-code)