### PR TITLE
Add N&N for animated effects migrated to SWT GraphicsExample

### DIFF
--- a/news/4.40/platform_isv.md
+++ b/news/4.40/platform_isv.md
@@ -76,10 +76,10 @@ Newly available effects include:
 - Unlimited Balls.
 - Warp.
 
-![Flower effect](images/graphics-example-flower.gif)
+<img src="images/graphics-example-flower.gif" alt="Flower effect" width="400">
 
-![Mirror effect](images/graphics-example-mirror.gif)
+<img src="images/graphics-example-mirror.gif" alt="Mirror effect" width="400">
 
-![Ripple effect](images/graphics-example-ripple.gif)
+<img src="images/graphics-example-ripple.gif" alt="Ripple effect" width="400">
 
-![Scroll effect](images/graphics-example-scroll.gif)
+<img src="images/graphics-example-scroll.gif" alt="Scroll effect" width="400">


### PR DESCRIPTION
## Summary
- Adds a 4.40 N&N entry for the animated demo tabs migrated from the SWT-OldSchoolEffect project into the new `Misc` category of `GraphicsExample`.
- Includes four demo GIFs (flower, mirror, ripple, scroll) bounded to `width="400"` so they render at a reasonable size on the website.
- Covers the migration tracked in https://github.com/eclipse-platform/eclipse.platform.swt/issues/3189.

## Test plan
- [ ] Preview `news/4.40/platform_isv.html` locally and confirm the new entry renders with correctly sized GIFs.
- [ ] Verify the `Misc` category bullet list renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)