### PR TITLE
Note planned default and feedback link for tab dirty indicator

### DIFF
--- a/news/4.40/platform.md
+++ b/news/4.40/platform.md
@@ -127,6 +127,8 @@ replacing the leading asterisk (`*`) in the tab title.
 You can enable it via `Indicate unsaved changes by overlaying the close button` in `Preferences > General > Appearance`,
 under `Dirty indicator for view and editor tabs`.
 The setting takes effect immediately for all open stacks.
+This is planned to become the default in the next release.
+Please share your feedback in [eclipse.platform.ui#4045](https://github.com/eclipse-platform/eclipse.platform.ui/issues/4045).
 
 ![Dirty indicator in light theme](images/view-editor-tab-dirty-indicator-light.png)
 


### PR DESCRIPTION
Adds a short note to the 4.40 N&N entry for the new tab dirty indicator, letting readers know it is planned to become the default in the next release and pointing them to the feedback issue (eclipse.platform.ui#4045). This gives users a clear channel to weigh in before the default changes.