### PR TITLE
Consider all active repositories for acknowledgements

### DIFF
--- a/.github/workflows/generateAcknowledgements.yml
+++ b/.github/workflows/generateAcknowledgements.yml
@@ -17,23 +17,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - name: Checkout Eclipse-Platform Releng Aggregator
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        repository: eclipse-platform/eclipse.platform.releng.aggregator
-        ref: master
-        path: eclipse.platform.releng.aggregator
     - name: Checkout website
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         path: website
-    - name: Collect Eclipse TLP repositories
-      id: collect-repos
-      working-directory: eclipse.platform.releng.aggregator
-      run: |
-        repos=$(git config --file .gitmodules --get-regexp '\.url$' | awk '{print $2}' | tr '\n' ' ')
-        echo "repos: ${repos}"
-        echo "repos=${repos}" >> "$GITHUB_OUTPUT"
     - name: Collect contributors
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       id: collect-contributors
@@ -53,22 +40,24 @@ jobs:
           // ----------------------------------------------
           // Collect all repositories
           // ----------------------------------------------
-          const submoduleURLs = '${{ steps.collect-repos.outputs.repos }}'.trim()
-          console.log("Repo list is: " + submoduleURLs)
-          const ghBaseURL = 'https://github.com/'
-          const gitSuffix = '.git'
-          const allRepos = submoduleURLs.split(' ').map(url => {
-            if (!url.startsWith(ghBaseURL) || !url.endsWith(gitSuffix)) {
-              core.error('Unsupported repository URL format: ' + url)
-              throw new Error('Unsupported repository URL format: ' + url)
+          const organizations = ['eclipse-platform', 'eclipse-equinox', 'eclipse-jdt', 'eclipse-pde']
+          const ignoredRepos = new Set(['.github', '.eclipsefdn'])
+          const allRepos = []
+          for (const orga of organizations) {
+            // https://octokit.github.io/rest.js/v22/#repos-list-for-org
+            // About pagination, see https://github.com/octokit/octokit.js#pagination
+            let responseIterator = github.paginate.iterator(github.rest.repos.listForOrg, {
+              org: orga, type: 'public',
+            })
+            for await (const { data: repos } of responseIterator) { // iterate through each response
+              for (const repo of repos) {
+                if (repo.archived || ignoredRepos.has(repo.name)) {
+                  continue
+                }
+                allRepos.push(repo.full_name)
+              }
             }
-            const repo = url.substring(ghBaseURL.length, url.length - gitSuffix.length)
-            if (repo.split('/').length != 2) {
-              throw new Error('Unsupported repository URL format: ' + url)
-            }
-            return repo
-          })
-          allRepos.unshift('eclipse-platform/eclipse.platform.releng.aggregator')
+          }
           console.log('All repositories: ' + allRepos)
           
           // ----------------------------------------------


### PR DESCRIPTION
Consider all active repositories for generated acknowledgements.

While testing this I noticed the non trivial problem, that for the newly considered repos no release tags are available (yet).
To solve this, we could either add tags to these repositories, but this again would be a non trivial task.
Alternatively in the new repositories the commits belonging to a release could be computed based on their dates.
There is now an 'API' that provides the SimRel dates, e.g.:
https://github.com/eclipse-simrel/.github/blob/main/wiki/SimRel/2026-06_dates.json

The Github REST API also provides means to obtain all commits between two dates:
https://docs.github.com/en/rest/commits/commits?apiVersion=2026-03-10#list-commits


Fixes https://github.com/eclipse-platform/www.eclipse.org-eclipse/issues/485


CC @BeckerWdf
