### PR TITLE
use markdown lists for foreach quick assist contributors

### DIFF
--- a/news/4.41/jdt.md
+++ b/news/4.41/jdt.md
@@ -38,8 +38,8 @@ This makes it easier to inspect implementations, compare code, and work with mul
 <details>
 <summary>Contributors</summary>
 
-[Ivan Gualandri](https://github.com/inuyasha82)
-[Carsten Hammer](https://github.com/carstenartur)
+- [Ivan Gualandri](https://github.com/inuyasha82)
+- [Carsten Hammer](https://github.com/carstenartur)
 </details>
 
 With this new quick assist, on an enhanced for-loop such as the following:


### PR DESCRIPTION
This PR fixes the contributor section in the N&N for the quick assist that converts enhanced for loops to `.forEach` method calls to make sure the images are correctly displayed.

<img width="1178" height="558" alt="image" src="https://github.com/user-attachments/assets/b48318ad-6c80-4b78-ad4b-6f299c244113" />
